### PR TITLE
Add .gitignore for project and audio-specific requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.git/*
+
+.venv/
+
+__pycache__/
+

--- a/src/audio/requirements.txt
+++ b/src/audio/requirements.txt
@@ -1,0 +1,6 @@
+colorednoise==2.2.0
+librosa==0.11.0
+numpy==2.2.5
+pyqt5==5.15.11
+scipy==1.15.2
+slab==1.8.0


### PR DESCRIPTION
1. Add `.gitignore` to avoid uploading pycache, etc.
2. Add audio `requirements.txt` for simpler usage