### PR TITLE
Add PyQt theme toggling

### DIFF
--- a/src/sequence_editor.py
+++ b/src/sequence_editor.py
@@ -1,8 +1,18 @@
 import sys
 
 from PyQt5 import sip
-from PyQt5.QtWidgets import (QMainWindow, QWidget, QHBoxLayout, QApplication,
-                             QStatusBar, QAction, QFileDialog, QMessageBox)
+from PyQt5.QtWidgets import (
+    QMainWindow,
+    QWidget,
+    QHBoxLayout,
+    QApplication,
+    QStatusBar,
+    QAction,
+    QFileDialog,
+    QMessageBox,
+)
+from functools import partial
+from ui import themes
 from ui.step_list_panel import StepListPanel
 from ui.step_config_panel import StepConfigPanel
 # REMOVED: from ui.audio_settings_panel import AudioSettingsPanel
@@ -96,12 +106,21 @@ class MainWindow(QMainWindow):
         simulator_act.triggered.connect(self.open_simulator)
         simulator_menu.addAction(simulator_act)
 
+        theme_menu = menubar.addMenu("Theme")
+        for name in themes.THEMES.keys():
+            act = QAction(name, self)
+            act.triggered.connect(partial(self.set_theme, name))
+            theme_menu.addAction(act)
+
     def open_simulator(self):
         if self.simulator_window is None:
             self.simulator_window = SimulatorWindow(self)
         self.simulator_window.show()
         self.simulator_window.raise_()
         self.simulator_window.activateWindow()
+
+    def set_theme(self, name):
+        themes.apply_theme(QApplication.instance(), name)
 
     def update_sequence_duration(self):
         duration = self.step_controller.update_sequence_duration()
@@ -590,6 +609,7 @@ class MainWindow(QMainWindow):
 
 def main():
     app = QApplication(sys.argv)
+    themes.apply_theme(app, "Dark")
     win = MainWindow()
     win.show()
     sys.exit(app.exec_())

--- a/src/ui/themes.py
+++ b/src/ui/themes.py
@@ -1,0 +1,106 @@
+from PyQt5.QtWidgets import QApplication
+from PyQt5.QtGui import QPalette, QColor
+from dataclasses import dataclass
+
+@dataclass
+class Theme:
+    palette_func: callable
+    stylesheet: str = ""
+
+def dark_palette() -> QPalette:
+    palette = QPalette()
+    palette.setColor(QPalette.Window, QColor(53, 53, 53))
+    palette.setColor(QPalette.WindowText, QColor(255, 255, 255))
+    palette.setColor(QPalette.Base, QColor(25, 25, 25))
+    palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
+    palette.setColor(QPalette.ToolTipBase, QColor(0, 0, 0))
+    palette.setColor(QPalette.ToolTipText, QColor(255, 255, 255))
+    palette.setColor(QPalette.Text, QColor(255, 255, 255))
+    palette.setColor(QPalette.Button, QColor(53, 53, 53))
+    palette.setColor(QPalette.ButtonText, QColor(255, 255, 255))
+    palette.setColor(QPalette.BrightText, QColor(255, 0, 0))
+    palette.setColor(QPalette.Link, QColor(42, 130, 218))
+    palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
+    palette.setColor(QPalette.HighlightedText, QColor(0, 0, 0))
+    return palette
+
+# Green cymatic theme derived from the example in README
+GLOBAL_STYLE_SHEET_GREEN = """
+/* Base Widget Styling */
+QWidget {
+    font-size: 10pt;
+    background-color: #0a0a0a;
+    color: #00ffaa;
+    font-family: 'Consolas', 'Courier New', monospace;
+}
+
+/* Group Boxes */
+QGroupBox {
+    background-color: #1a1a1a;
+    border: 1px solid rgba(0, 255, 136, 0.4);
+    border-radius: 4px;
+    margin-top: 8px;
+    padding-top: 8px;
+}
+
+QGroupBox::title {
+    color: #00ffaa;
+    subcontrol-origin: margin;
+    left: 10px;
+    padding: 0 3px 0 3px;
+    background-color: #1a1a1a;
+}
+
+/* Push Buttons */
+QPushButton {
+    background-color: rgba(0, 255, 136, 0.25);
+    border: 1px solid #00ff88;
+    color: #00ffaa;
+    padding: 4px 12px;
+    border-radius: 4px;
+    font-weight: bold;
+}
+
+QPushButton:hover {
+    background-color: rgba(0, 255, 136, 0.4);
+    border: 1px solid #00ffcc;
+    box-shadow: 0 0 10px rgba(0, 255, 136, 0.6);
+}
+
+QPushButton:pressed {
+    background-color: rgba(0, 255, 136, 0.6);
+}
+
+QPushButton:disabled {
+    background-color: rgba(0, 136, 68, 0.2);
+    border: 1px solid rgba(0, 255, 136, 0.2);
+    color: rgba(0, 255, 136, 0.5);
+}
+"""
+
+def green_palette() -> QPalette:
+    palette = QPalette()
+    palette.setColor(QPalette.Window, QColor(0x0a, 0x0a, 0x0a))
+    palette.setColor(QPalette.WindowText, QColor(0x00, 0xff, 0xaa))
+    palette.setColor(QPalette.Base, QColor(0x1a, 0x1a, 0x1a))
+    palette.setColor(QPalette.AlternateBase, QColor(0x15, 0x20, 0x15))
+    palette.setColor(QPalette.Text, QColor(0x00, 0xff, 0xaa))
+    palette.setColor(QPalette.Button, QColor(0x00, 0x88, 0x44, 0x60))
+    palette.setColor(QPalette.ButtonText, QColor(0x00, 0xff, 0xaa))
+    palette.setColor(QPalette.Highlight, QColor(0x00, 0xff, 0x88, 0xaa))
+    palette.setColor(QPalette.HighlightedText, QColor(0xff, 0xff, 0xff))
+    palette.setColor(QPalette.Link, QColor(0x00, 0xff, 0xcc))
+    return palette
+
+THEMES = {
+    "Dark": Theme(dark_palette, ""),
+    "Green": Theme(green_palette, GLOBAL_STYLE_SHEET_GREEN),
+}
+
+def apply_theme(app: QApplication, name: str):
+    theme = THEMES.get(name)
+    if not theme:
+        return
+    palette = theme.palette_func()
+    app.setPalette(palette)
+    app.setStyleSheet(theme.stylesheet)


### PR DESCRIPTION
## Summary
- add new module `src/ui/themes.py` defining color palettes and stylesheets
- update `sequence_editor.py` to load themes, add menu for theme selection, and apply a default theme

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684207ffdcf8832d98f51417c0a12448