### PR TITLE
Add persistent user settings

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -43,7 +43,8 @@ from PyQt5.QtMultimedia import (
 
 from functools import partial
 from ui import themes
-from preferences import load_preferences, save_preferences, Preferences
+from preferences import Preferences
+from settings_file import load_settings, save_settings
 from ui.preferences_dialog import PreferencesDialog
 
 # Attempt to import VoiceEditorDialog. Handle if ui/voice_editor_dialog.py is not found.
@@ -132,7 +133,7 @@ except ImportError as e:
 class TrackEditorApp(QMainWindow):
     def __init__(self, prefs: Preferences = None):
         super().__init__()
-        self.prefs: Preferences = prefs or load_preferences()
+        self.prefs: Preferences = prefs or load_settings()
         self.apply_preferences()
         self.setWindowTitle("Binaural Track Editor (PyQt5)")
         self.setMinimumSize(950, 600)
@@ -221,13 +222,13 @@ class TrackEditorApp(QMainWindow):
         self.setStyleSheet(GLOBAL_STYLE_SHEET)
         if hasattr(self, "prefs"):
             self.prefs.theme = name
-            save_preferences(self.prefs)
+            save_settings(self.prefs)
 
     def open_preferences(self):
         dialog = PreferencesDialog(self.prefs, self)
         if dialog.exec_() == QDialog.Accepted:
             self.prefs = dialog.get_preferences()
-            save_preferences(self.prefs)
+            save_settings(self.prefs)
             self.apply_preferences()
 
     def apply_preferences(self):
@@ -1637,7 +1638,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     app = QApplication(sys.argv)
-    prefs = load_preferences()
+    prefs = load_settings()
     if prefs.font_family or prefs.font_size:
         font = QFont(prefs.font_family or app.font().family(), prefs.font_size)
         app.setFont(font)

--- a/src/audio/settings_file.py
+++ b/src/audio/settings_file.py
@@ -1,0 +1,38 @@
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from .preferences import Preferences
+
+# Settings file path located in the user's home directory
+SETTINGS_FILE = Path.home() / ".entrainment_prefs.json"
+
+
+def load_settings() -> Preferences:
+    """Load preferences from ``SETTINGS_FILE``.
+
+    Returns a :class:`Preferences` instance populated with the values found in
+    the JSON file. If the file does not exist or cannot be read, defaults are
+    returned.
+    """
+    if SETTINGS_FILE.is_file():
+        try:
+            with open(SETTINGS_FILE, "r") as f:
+                data = json.load(f)
+            prefs = Preferences()
+            for k, v in data.items():
+                if hasattr(prefs, k):
+                    setattr(prefs, k, v)
+            return prefs
+        except Exception as e:
+            print(f"Failed to load preferences: {e}")
+    return Preferences()
+
+
+def save_settings(prefs: Preferences) -> None:
+    """Save the given ``Preferences`` instance to ``SETTINGS_FILE``."""
+    try:
+        with open(SETTINGS_FILE, "w") as f:
+            json.dump(asdict(prefs), f, indent=2)
+    except Exception as e:
+        print(f"Failed to save preferences: {e}")


### PR DESCRIPTION
## Summary
- store user preferences in a JSON settings file
- load and save this file from the audio editor

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68446372a28c832daa9be2b4170b8917