### PR TITLE
Fix dark theme text color

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -97,12 +97,12 @@ QPushButton {
 }
 QTreeWidget {
     background-color: #2b2b2b;
-    color: #000000;
+    color: #ffffff;
 }
 QLineEdit, QComboBox, QSlider {
     background-color: #202020;
     border: 1px solid #555555;
-    color: #000000;
+    color: #ffffff;
 }
 """
 

--- a/src/audio/ui/themes.py
+++ b/src/audio/ui/themes.py
@@ -23,6 +23,16 @@ def dark_palette() -> QPalette:
     palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
     palette.setColor(QPalette.HighlightedText, QColor(0, 0, 0))
     return palette
+
+# Style sheet ensuring editable widgets use white text in the dark theme
+GLOBAL_STYLE_SHEET_DARK = """
+QTreeWidget {
+    color: #ffffff;
+}
+QLineEdit, QComboBox, QSlider {
+    color: #ffffff;
+}
+"""
     
 # Green cymatic theme derived from the example in README
 GLOBAL_STYLE_SHEET_GREEN = """
@@ -105,7 +115,7 @@ def green_palette() -> QPalette:
     return palette
 
 THEMES = {
-    "Dark": Theme(dark_palette, ""),
+    "Dark": Theme(dark_palette, GLOBAL_STYLE_SHEET_DARK),
     "Green": Theme(green_palette, GLOBAL_STYLE_SHEET_GREEN),
 }
 


### PR DESCRIPTION
## Summary
- make tree widget items white in dark mode so they're readable
- include tree widget selector in dark theme stylesheet

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684467c45d7c832d878a6addc9f786ba