### PR TITLE
Add support for logarithmic and exponential transition curves

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -145,6 +145,16 @@ Each voice may optionally include a volume envelope definition:
 - `adsr` – attack, decay, sustain, and release times.
 - Leaving the envelope undefined applies a small 10 ms fade to avoid clicks.
 
+## Transition Curves
+Transition voices accept a `transition_curve` parameter controlling how values
+move from their start settings to the final ones. Supported options are:
+
+- `linear` – constant rate from start to finish (default).
+- `logarithmic` – fast start that slows near the end.
+- `exponential` – slow start that accelerates toward the end.
+
+If omitted, `linear` is used.
+
 ---
 
 ## Tips

--- a/src/audio/synth_functions/binaural_beat.py
+++ b/src/audio/synth_functions/binaural_beat.py
@@ -323,7 +323,8 @@ def binaural_beat_transition(duration, sample_rate=44100, initial_offset=0.0, po
         pos_arr   = np.empty(0, dtype=np.int32)
         burst_arr = np.empty(0, dtype=np.float32)
 
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     return _binaural_beat_transition_core(
         N, float(duration), float(sample_rate),

--- a/src/audio/synth_functions/common.py
+++ b/src/audio/synth_functions/common.py
@@ -483,8 +483,20 @@ def apply_filters(signal_segment, fs):
     return signal_segment
 
 
-def calculate_transition_alpha(total_duration, sample_rate, initial_offset=0.0, post_offset=0.0):
-    """Create an interpolation factor array taking start/end offsets into account."""
+def calculate_transition_alpha(total_duration, sample_rate, initial_offset=0.0, post_offset=0.0, curve="linear"):
+    """Create an interpolation factor array taking start/end offsets into account.
+
+    Args:
+        total_duration (float): Length of the transition in seconds.
+        sample_rate (float): Sampling rate of the generated audio.
+        initial_offset (float): Time before the transition begins.
+        post_offset (float): Time after the transition ends.
+        curve (str): Name of the transition curve to apply. Supported values are
+            ``"linear"`` (default), ``"logarithmic"``, and ``"exponential"``.
+
+    Returns:
+        np.ndarray: Array of interpolation factors in the range [0, 1].
+    """
     total_duration = float(total_duration)
     sample_rate = float(sample_rate)
     initial_offset = max(0.0, float(initial_offset))
@@ -508,5 +520,15 @@ def calculate_transition_alpha(total_duration, sample_rate, initial_offset=0.0, 
 
     alpha = (t - start_t) / trans_time
     alpha = np.clip(alpha, 0.0, 1.0)
+
+    if curve == "linear":
+        pass  # already linear
+    elif curve == "logarithmic":
+        alpha = 1.0 - np.power(1.0 - alpha, 2.0)
+    elif curve == "exponential":
+        alpha = np.power(alpha, 2.0)
+    else:
+        raise ValueError(f"Unknown transition curve '{curve}'")
+
     return alpha
 

--- a/src/audio/synth_functions/hybrid_qam_monaural_beat.py
+++ b/src/audio/synth_functions/hybrid_qam_monaural_beat.py
@@ -216,7 +216,8 @@ def hybrid_qam_monaural_beat_transition(duration, sample_rate=44100, initial_off
     if N <= 0:
         return np.zeros((0, 2), dtype=np.float32)
 
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     raw_signal = _hybrid_qam_monaural_beat_transition_core(
         N, float(duration), float(sample_rate),

--- a/src/audio/synth_functions/isochronic_tone.py
+++ b/src/audio/synth_functions/isochronic_tone.py
@@ -84,7 +84,8 @@ def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, 
 
     t_abs = np.linspace(0, duration, N, endpoint=False)
 
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     # --- Interpolate Frequencies ---
     base_freq_array = startBaseFreq + (endBaseFreq - startBaseFreq) * alpha

--- a/src/audio/synth_functions/monaural_beat_stereo_amps.py
+++ b/src/audio/synth_functions/monaural_beat_stereo_amps.py
@@ -150,7 +150,8 @@ def monaural_beat_stereo_amps_transition(duration, sample_rate=44100, initial_of
     eAOP = float(params.get('endAmpOscPhaseOffset', sAOP))
 
     N = int(duration * sample_rate)
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
     return _monaural_beat_stereo_amps_transition_core(
         N, float(duration), float(sample_rate),
         s_ll, e_ll, s_ul, e_ul, s_lr, e_lr, s_ur, e_ur,

--- a/src/audio/synth_functions/qam_beat.py
+++ b/src/audio/synth_functions/qam_beat.py
@@ -339,7 +339,8 @@ def qam_beat_transition(duration, sample_rate=44100, initial_offset=0.0, post_of
     if N <= 0:
         return np.zeros((0, 2), dtype=np.float32)
     
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     raw_signal = _qam_beat_transition_core(
         N, float(duration), float(sample_rate),

--- a/src/audio/synth_functions/rhythmic_waveshaping.py
+++ b/src/audio/synth_functions/rhythmic_waveshaping.py
@@ -57,7 +57,8 @@ def rhythmic_waveshaping_transition(duration, sample_rate=44100, initial_offset=
     t_rel = np.linspace(0, duration, N, endpoint=False)
     t_abs = t_rel
 
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     # Interpolate parameters using alpha
     currentCarrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * alpha

--- a/src/audio/synth_functions/stereo_am_independent.py
+++ b/src/audio/synth_functions/stereo_am_independent.py
@@ -65,7 +65,8 @@ def stereo_am_independent_transition(duration, sample_rate=44100, initial_offset
     t_rel = np.linspace(0, duration, N, endpoint=False)
     t_abs = t_rel
 
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     # Interpolate parameters using alpha
     currentCarrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * alpha

--- a/src/audio/synth_functions/wave_shape_stereo_am.py
+++ b/src/audio/synth_functions/wave_shape_stereo_am.py
@@ -83,7 +83,8 @@ def wave_shape_stereo_am_transition(duration, sample_rate=44100, initial_offset=
     t_rel = np.linspace(0, duration, N, endpoint=False)
     t_abs = t_rel
 
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset)
+    curve = params.get('transition_curve', 'linear')
+    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     # Interpolate parameters using alpha
     currentCarrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * alpha

--- a/src/audio/ui/voice_editor_dialog.py
+++ b/src/audio/ui/voice_editor_dialog.py
@@ -809,7 +809,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startModFreq', 12), ('endModFreq', 7.83),
                     ('startModDepth', 1.0), ('endModDepth', 1.0),
                     ('startShapeAmount', 5.0), ('endShapeAmount', 5.0), ('pan', 0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "stereo_am_independent": { # This is an example, ensure it's correct
@@ -827,7 +827,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startModDepthR', 0.8), ('endModDepthR', 0.8),
                     ('startModPhaseR', 0),
                     ('startStereoWidthHz', 0.2), ('endStereoWidthHz', 0.2),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "wave_shape_stereo_am": { # This is an example, ensure it's correct
@@ -849,7 +849,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startStereoModFreqR', 4.0), ('endStereoModFreqR', 6.1),
                     ('startStereoModDepthR', 0.9), ('endStereoModDepthR', 0.9),
                     ('startStereoModPhaseR', math.pi / 2),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "spatial_angle_modulation_engine": { # This is an example, ensure it's correct
@@ -868,7 +868,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startArcStartDeg', 0.0), ('endArcStartDeg', 0.0),
                     ('startArcEndDeg', 360.0), ('endArcEndDeg', 360.0),
                     ('frame_dur_ms', 46.4), ('overlap_factor', 8),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "binaural_beat": { # This is an example, ensure it's correct
@@ -909,7 +909,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startGlitchNoiseLevel', 0.0), ('endGlitchNoiseLevel', 0.0),
                     ('startGlitchFocusWidth', 0.0), ('endGlitchFocusWidth', 0.0),
                     ('startGlitchFocusExp', 0.0), ('endGlitchFocusExp', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "monaural_beat_stereo_amps": { # This is an example, ensure it's correct
@@ -935,7 +935,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startAmpOscDepth', 0.0), ('endAmpOscDepth', 0.0),
                     ('startAmpOscFreq', 0.0), ('endAmpOscFreq', 0.0),
                     ('startAmpOscPhaseOffset', 0.0), ('endAmpOscPhaseOffset', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "spatial_angle_modulation_monaural": { # This is an example, ensure it's correct
@@ -974,7 +974,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startPathRadius', 1.0), ('endPathRadius', 1.0),
                     ('startAmp', 0.7), ('endAmp', 0.7),
                     ('frame_dur_ms', 46.4), ('overlap_factor', 8),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "isochronic_tone": { # This is an example, ensure it's correct
@@ -986,7 +986,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('amp', 0.5), ('startBaseFreq', 200.0), ('endBaseFreq', 200.0),
                     ('startBeatFreq', 4.0), ('endBeatFreq', 4.0),
                     ('rampPercent', 0.2), ('gapPercent', 0.15), ('pan', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "qam_beat": { # CORRECTED AND COMPLETED for qam_beat based on qam_beat.py
@@ -1042,7 +1042,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('sidebandDepth', 0.1),
                     ('attackTime', 0.0),
                     ('releaseTime', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "hybrid_qam_monaural_beat": { # This is an example, ensure it's correct
@@ -1077,7 +1077,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startMonoPhaseOscFreqR', 0.0), ('endMonoPhaseOscFreqR', 0.0),
                     ('startMonoPhaseOscRangeR', 0.0), ('endMonoPhaseOscRangeR', 0.0),
                     ('startMonoPhaseOscPhaseOffsetR', 0.0), ('endMonoPhaseOscPhaseOffsetR', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0)
+                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             }
         }


### PR DESCRIPTION
## Summary
- enable custom parameter transition curves
- implement logarithmic and exponential transitions
- document the new `transition_curve` option in the audio README
- expose `transition_curve` in the voice editor UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845ca18d6a4832d9cab27e4d6fbf37c