### PR TITLE
Add custom transition curve support

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -153,6 +153,14 @@ move from their start settings to the final ones. Supported options are:
 - `logarithmic` – fast start that slows near the end.
 - `exponential` – slow start that accelerates toward the end.
 
+Any other string will be evaluated as a Python expression using `alpha` as the
+linear ramp from 0 to 1. `numpy` is available via `np` and `math` functions may
+be used as well. For example:
+
+```python
+transition_curve="np.sin(alpha * np.pi / 2)"
+```
+
 If omitted, `linear` is used.
 
 ---

--- a/src/audio/synth_functions/common.py
+++ b/src/audio/synth_functions/common.py
@@ -493,6 +493,9 @@ def calculate_transition_alpha(total_duration, sample_rate, initial_offset=0.0, 
         post_offset (float): Time after the transition ends.
         curve (str): Name of the transition curve to apply. Supported values are
             ``"linear"`` (default), ``"logarithmic"``, and ``"exponential"``.
+            Any other string is interpreted as a Python expression using
+            ``alpha`` as the linear ramp (0-1). ``numpy`` can be accessed via
+            ``np`` and ``math`` for more advanced shapes.
 
     Returns:
         np.ndarray: Array of interpolation factors in the range [0, 1].
@@ -528,7 +531,12 @@ def calculate_transition_alpha(total_duration, sample_rate, initial_offset=0.0, 
     elif curve == "exponential":
         alpha = np.power(alpha, 2.0)
     else:
-        raise ValueError(f"Unknown transition curve '{curve}'")
+        try:
+            alpha = eval(str(curve), {"np": np, "math": math}, {"alpha": alpha})
+        except Exception as exc:
+            raise ValueError(
+                f"Invalid transition curve expression '{curve}': {exc}"
+            ) from exc
 
     return alpha
 


### PR DESCRIPTION
## Summary
- allow calculate_transition_alpha to evaluate custom expressions
- document new transition_curve usage notes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485a5ef828832d989ecd00102ced03