### PR TITLE
Add frequency tester dialog

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -47,6 +47,7 @@ from preferences import Preferences
 from settings_file import load_settings, save_settings
 from ui.preferences_dialog import PreferencesDialog
 from ui.noise_generator_dialog import NoiseGeneratorDialog
+from ui.frequency_tester_dialog import FrequencyTesterDialog
 
 # Attempt to import VoiceEditorDialog. Handle if ui/voice_editor_dialog.py is not found.
 try:
@@ -239,6 +240,10 @@ class TrackEditorApp(QMainWindow):
         dialog = NoiseGeneratorDialog(self)
         dialog.exec_()
 
+    def open_frequency_tester(self):
+        dialog = FrequencyTesterDialog(self, self.prefs)
+        dialog.exec_()
+
     def apply_preferences(self):
         app = QApplication.instance()
         if self.prefs.font_family or self.prefs.font_size:
@@ -278,6 +283,9 @@ class TrackEditorApp(QMainWindow):
         self.open_noise_button = QPushButton("Open Noise Generator")
         self.open_noise_button.clicked.connect(self.open_noise_generator)
         file_ops_layout.addWidget(self.open_noise_button)
+        self.open_freq_tester_button = QPushButton("Frequency Tester")
+        self.open_freq_tester_button.clicked.connect(self.open_frequency_tester)
+        file_ops_layout.addWidget(self.open_freq_tester_button)
         file_ops_layout.addStretch(1)
         control_layout.addWidget(file_ops_groupbox)
 

--- a/src/audio/ui/__init__.py
+++ b/src/audio/ui/__init__.py
@@ -1,0 +1,1 @@
+from .frequency_tester_dialog import FrequencyTesterDialog

--- a/src/audio/ui/frequency_tester_dialog.py
+++ b/src/audio/ui/frequency_tester_dialog.py
@@ -1,0 +1,162 @@
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QWidget,
+    QLabel, QCheckBox, QDoubleSpinBox, QPushButton, QMessageBox
+)
+from PyQt5.QtCore import Qt, QBuffer, QIODevice
+from PyQt5.QtMultimedia import QAudioOutput, QAudioFormat, QAudioDeviceInfo, QAudio
+
+import numpy as np
+
+from synth_functions.binaural_beat import binaural_beat
+
+try:
+    from ..preferences import Preferences
+except ImportError:  # when running stand-alone
+    from preferences import Preferences
+
+
+class FrequencyTesterDialog(QDialog):
+    """Dialog for quickly previewing multiple binaural voices."""
+
+    MAX_VOICES = 10
+    SEGMENT_DURATION_S = 60
+
+    def __init__(self, parent=None, prefs: Preferences = None):
+        super().__init__(parent)
+        self.prefs = prefs or Preferences()
+        self.audio_output = None
+        self.audio_buffer = None
+
+        self.setWindowTitle("Frequency Tester")
+        self.resize(600, 0)
+
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+
+        self.voice_controls = []  # list of dicts
+        for i in range(self.MAX_VOICES):
+            enabled = QCheckBox(f"Voice {i + 1}")
+            base_spin = QDoubleSpinBox()
+            base_spin.setRange(20.0, 20000.0)
+            base_spin.setValue(200.0)
+            base_spin.setDecimals(2)
+            beat_spin = QDoubleSpinBox()
+            beat_spin.setRange(0.0, 40.0)
+            beat_spin.setValue(4.0)
+            beat_spin.setDecimals(2)
+            amp_spin = QDoubleSpinBox()
+            amp_spin.setRange(0.0, 1.0)
+            amp_spin.setSingleStep(0.05)
+            amp_spin.setValue(0.5)
+            row = QWidget()
+            row_layout = QHBoxLayout(row)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+            row_layout.addWidget(enabled)
+            row_layout.addWidget(QLabel("Base Freq"))
+            row_layout.addWidget(base_spin)
+            row_layout.addWidget(QLabel("Beat Freq"))
+            row_layout.addWidget(beat_spin)
+            row_layout.addWidget(QLabel("Amp"))
+            row_layout.addWidget(amp_spin)
+            form.addRow(row)
+            self.voice_controls.append({
+                "enable": enabled,
+                "base": base_spin,
+                "beat": beat_spin,
+                "amp": amp_spin,
+            })
+
+        layout.addLayout(form)
+
+        btn_row = QHBoxLayout()
+        self.start_btn = QPushButton("Start")
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.setEnabled(False)
+        self.start_btn.clicked.connect(self.on_start)
+        self.stop_btn.clicked.connect(self.on_stop)
+        btn_row.addStretch(1)
+        btn_row.addWidget(self.start_btn)
+        btn_row.addWidget(self.stop_btn)
+        layout.addLayout(btn_row)
+
+    def generate_audio(self):
+        sample_rate = int(self.prefs.sample_rate) if hasattr(self.prefs, "sample_rate") else 44100
+        duration = self.SEGMENT_DURATION_S
+        total_samples = int(duration * sample_rate)
+        mix = np.zeros((total_samples, 2), dtype=np.float32)
+
+        any_enabled = False
+        for vc in self.voice_controls:
+            if vc["enable"].isChecked():
+                any_enabled = True
+                base = vc["base"].value()
+                beat = vc["beat"].value()
+                amp = vc["amp"].value()
+                voice = binaural_beat(duration, sample_rate=sample_rate,
+                                       ampL=amp, ampR=amp,
+                                       baseFreq=base, beatFreq=beat)
+                if voice.shape[0] < total_samples:
+                    voice = np.pad(voice, ((0, total_samples - voice.shape[0]), (0, 0)))
+                mix += voice
+        if not any_enabled:
+            return None, sample_rate
+
+        peak = np.max(np.abs(mix))
+        if peak > 1.0:
+            mix /= peak
+        audio_int16 = (np.clip(mix, -1.0, 1.0) * 32767).astype(np.int16)
+        return audio_int16.tobytes(), sample_rate
+
+    def on_start(self):
+        data, sr = self.generate_audio()
+        if data is None:
+            QMessageBox.warning(self, "Frequency Tester", "No voices enabled")
+            return
+        fmt = QAudioFormat()
+        fmt.setCodec("audio/pcm")
+        fmt.setSampleRate(sr)
+        fmt.setSampleSize(16)
+        fmt.setChannelCount(2)
+        fmt.setByteOrder(QAudioFormat.LittleEndian)
+        fmt.setSampleType(QAudioFormat.SignedInt)
+        device_info = QAudioDeviceInfo.defaultOutputDevice()
+        if not device_info.isFormatSupported(fmt):
+            QMessageBox.warning(self, "Audio Format", "Default output device does not support the required format")
+            return
+
+        if self.audio_output:
+            self.audio_output.stop()
+            self.audio_output = None
+        self.audio_output = QAudioOutput(fmt, self)
+        self.audio_output.stateChanged.connect(self._handle_state_change)
+
+        self.audio_buffer = QBuffer()
+        self.audio_buffer.setData(data)
+        self.audio_buffer.open(QIODevice.ReadOnly)
+
+        self.audio_output.start(self.audio_buffer)
+        self.start_btn.setEnabled(False)
+        self.stop_btn.setEnabled(True)
+
+    def _handle_state_change(self, state):
+        if state == QAudio.IdleState and self.audio_output and self.audio_buffer:
+            # Loop playback
+            self.audio_buffer.seek(0)
+            self.audio_output.start(self.audio_buffer)
+
+    def on_stop(self):
+        if self.audio_output:
+            self.audio_output.stop()
+            self.audio_output = None
+        if self.audio_buffer:
+            self.audio_buffer.close()
+            self.audio_buffer = None
+        self.start_btn.setEnabled(True)
+        self.stop_btn.setEnabled(False)
+
+    def closeEvent(self, event):
+        self.on_stop()
+        super().closeEvent(event)


### PR DESCRIPTION
## Summary
- add new frequency tester dialog to program up to 10 binaural voices
- expose the dialog through `ui.__init__`
- wire up `FrequencyTesterDialog` from the main window with a new button

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6848fa141c88832db308b942be768cc9