### PR TITLE
Add transition support to noise generator

### DIFF
--- a/src/audio/synth_functions/__init__.py
+++ b/src/audio/synth_functions/__init__.py
@@ -41,4 +41,5 @@ __all__ = [
     'spatial_angle_modulation_monaural_beat',
     'spatial_angle_modulation_monaural_beat_transition',
     'generate_swept_notch_pink_sound',
+    'generate_swept_notch_pink_sound_transition',
 ]


### PR DESCRIPTION
## Summary
- allow noise generator to display start/end values and handle transitions
- centralize core noise generation logic and add helper for arrays
- support transitions for swept notch noise

## Testing
- `python -m py_compile src/audio/ui/noise_generator_dialog.py src/audio/synth_functions/noise_flanger.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5eca3eb4832da4674564f38d8c34