### PR TITLE
Fix swept notch transition args

### DIFF
--- a/src/audio/synth_functions/noise_flanger.py
+++ b/src/audio/synth_functions/noise_flanger.py
@@ -731,6 +731,15 @@ def generate_swept_notch_pink_sound_transition(
         start_lfo_phase_offset_deg,
         end_lfo_phase_offset_deg,
         start_intra_phase_offset_deg,
+        end_intra_phase_offset_deg,
+        input_audio_path,
+        noise_type,
+        lfo_waveform,
+        initial_offset,
+        post_offset,
+        transition_curve,
+        memory_efficient,
+        n_jobs,
     )
 
 
@@ -758,15 +767,10 @@ def generate_swept_notch_pink_sound_transition(
         end_notch_q,
         end_cascade_count,
         end_lfo_phase_offset_deg,
-
         end_intra_phase_offset_deg,
         input_audio_path,
         noise_type,
         lfo_waveform,
-
-        initial_offset,
-        post_offset,
-        transition_curve,
         memory_efficient,
         n_jobs,
     )


### PR DESCRIPTION
## Summary
- fix missing parameters when calling `_generate_swept_notch_arrays_transition`
- remove invalid parameters from `_generate_swept_notch_arrays` call

## Testing
- `python -m py_compile src/audio/synth_functions/noise_flanger.py`
- `python -m py_compile src/audio/ui/noise_generator_dialog.py`
- `find src -name '*.py' | xargs python -m py_compile`
- `PYTHONPATH=src/audio python - <<'PY'
from synth_functions.noise_flanger import generate_swept_notch_pink_sound_transition
print('begin')
generate_swept_notch_pink_sound_transition(filename='test.wav', duration_seconds=0.5, sample_rate=44100, n_jobs=1, memory_efficient=True)
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684b70d8d198832d95f9222285469155