### PR TITLE
Update step tester behavior

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -58,3 +58,15 @@ Available Synth Functions:
 
 ## GUI Overview
 ![Sequence Editor GUI with Voice Editor Dialog](https://github.com/user-attachments/assets/f39bcc5c-3505-4803-b201-8d2f05d44d3c)
+
+### Step Tester Preview
+The editor includes a "Test Step Preview" panel for quickly auditioning a single
+step without generating the entire track. When a step is selected, the preview
+duration adapts to the step length:
+
+* If the step is shorter than 180&nbsp;seconds, the preview plays the entire
+  step.
+* For longer steps, a 60&nbsp;second excerpt is generated.
+
+This behaviour ensures that very long steps do not delay the preview yet short
+steps can still be heard in full.

--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -1291,8 +1291,28 @@ class TrackEditorApp(QMainWindow):
             global_settings = self.track_data["global_settings"]
             sample_rate = global_settings["sample_rate"]
             
+            # Determine preview duration based on step length
+            step_duration = 0.0
+            try:
+                step_duration = float(step_data.get("duration", 0.0))
+            except (TypeError, ValueError):
+                step_duration = 0.0
+
+            if step_duration > 0.0:
+                if step_duration < 180.0:
+                    test_duration = step_duration
+                else:
+                    test_duration = 60.0
+            else:
+                test_duration = self.test_step_duration
+
             # Generate audio (float32, stereo)
-            audio_data_np_float32 = generate_single_step_audio_segment(step_data, global_settings, self.test_step_duration, self.test_step_duration)
+            audio_data_np_float32 = generate_single_step_audio_segment(
+                step_data,
+                global_settings,
+                test_duration,
+                test_duration,
+            )
             
             if audio_data_np_float32 is None or audio_data_np_float32.size == 0:
                 QMessageBox.critical(self, "Audio Generation Error", "Failed to generate test audio data (empty).")


### PR DESCRIPTION
## Summary
- adjust test step audio generation so preview duration adapts to step length
- document how the step tester chooses preview duration

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685073ff5fd0832db3016abdb1f33466