### PR TITLE
Add subliminal audio tool

### DIFF
--- a/src/audio/synth_functions/__init__.py
+++ b/src/audio/synth_functions/__init__.py
@@ -21,6 +21,7 @@ from .noise_flanger import (
     generate_swept_notch_pink_sound,
     generate_swept_notch_pink_sound_transition,
 )
+from .subliminals import subliminal_encode
 
 __all__ = [
     'rhythmic_waveshaping',
@@ -45,4 +46,5 @@ __all__ = [
     'spatial_angle_modulation_monaural_beat_transition',
     'generate_swept_notch_pink_sound',
     'generate_swept_notch_pink_sound_transition',
+    'subliminal_encode',
 ]

--- a/src/audio/synth_functions/subliminals.py
+++ b/src/audio/synth_functions/subliminals.py
@@ -1,0 +1,66 @@
+import numpy as np
+import soundfile as sf
+
+try:
+    import librosa
+except Exception:
+    librosa = None
+
+
+def subliminal_encode(duration, sample_rate=44100, **params):
+    """Encode an audio file as a high frequency subliminal message.
+
+    Parameters
+    ----------
+    duration : float
+        Length of the output audio in seconds.
+    sample_rate : int, optional
+        Target sample rate of the output.
+    params : dict
+        Should contain ``audio_path`` with the file to encode, ``carrierFreq``
+        for the ultrasonic modulation frequency (15000-20000 Hz) and ``amp``
+        for the output amplitude (0-1.0).
+    """
+    audio_path = params.get("audio_path")
+    carrier = float(params.get("carrierFreq", 17500.0))
+    amp = float(params.get("amp", 0.5))
+
+    carrier = np.clip(carrier, 15000.0, 20000.0)
+
+    N = int(duration * sample_rate)
+    if audio_path is None:
+        return np.zeros((N, 2), dtype=np.float32)
+
+    try:
+        data, sr = sf.read(audio_path)
+    except Exception:
+        return np.zeros((N, 2), dtype=np.float32)
+
+    if data.ndim > 1:
+        data = np.mean(data, axis=1)
+
+    if sr != sample_rate:
+        if librosa is not None:
+            data = librosa.resample(data, orig_sr=sr, target_sr=sample_rate)
+        else:
+            # fallback simple resample
+            t_old = np.linspace(0, len(data) / sr, num=len(data), endpoint=False)
+            t_new = np.linspace(0, len(data) / sr, num=int(len(data) * sample_rate / sr), endpoint=False)
+            data = np.interp(t_new, t_old, data)
+
+    if len(data) < N:
+        data = np.pad(data, (0, N - len(data)))
+    else:
+        data = data[:N]
+
+    t = np.arange(N) / float(sample_rate)
+    mod = np.sin(2 * np.pi * carrier * t)
+    out = data * mod
+
+    max_val = np.max(np.abs(out))
+    if max_val > 0:
+        out = out / max_val
+    out *= amp
+
+    stereo = np.column_stack((out, out))
+    return stereo.astype(np.float32)


### PR DESCRIPTION
## Summary
- add new synth function `subliminal_encode` to modulate audio into an ultrasonic band
- expose the new function from `synth_functions`
- add `SubliminalDialog` UI to attach subliminal audio to a step
- integrate the dialog with the main application and enable button logic

## Testing
- `python -m py_compile src/audio/main.py src/audio/synth_functions/__init__.py src/audio/synth_functions/subliminals.py src/audio/ui/subliminal_dialog.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68519dd1d3f0832da9253b5136eeee3f