### PR TITLE
Enable looping multiple subliminals

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -146,6 +146,16 @@ Moves a tone along a geometric path using the optional `audio_engine` module.
 ### spatial_angle_modulation_monaural_beat
 Combines the monaural beat voice with spatial angle modulation.  Parameters mirror those of `monaural_beat_stereo_amps` along with spatial movement controls (`spatialBeatFreq`, `spatialPhaseOffset`, `pathRadius`, etc.).
 
+### subliminal_encode
+Encodes audio files as ultrasonic subliminals. Multiple files may be supplied via `audio_paths` and can either be mixed together (`mode="stack"`) or played one after another (`mode="sequence"`). The chosen arrangement loops for the duration of the step.
+
+| Parameter | Default | Effect |
+|-----------|---------|-------|
+| `audio_path` / `audio_paths` | – | Path(s) to the audio file(s) to encode |
+| `mode` | `"sequence"` | Sequential or stacked playback |
+| `carrierFreq` | 17500 | Modulation frequency (15000‑20000 Hz) |
+| `amp` | 0.5 | Output level |
+
 ---
 
 ## Volume Envelopes

--- a/src/audio/synth_functions/subliminals.py
+++ b/src/audio/synth_functions/subliminals.py
@@ -8,7 +8,7 @@ except Exception:
 
 
 def subliminal_encode(duration, sample_rate=44100, **params):
-    """Encode an audio file as a high frequency subliminal message.
+    """Encode one or more audio files as high frequency subliminal messages.
 
     Parameters
     ----------
@@ -17,45 +17,81 @@ def subliminal_encode(duration, sample_rate=44100, **params):
     sample_rate : int, optional
         Target sample rate of the output.
     params : dict
-        Should contain ``audio_path`` with the file to encode, ``carrierFreq``
-        for the ultrasonic modulation frequency (15000-20000 Hz) and ``amp``
-        for the output amplitude (0-1.0).
+        ``audio_path`` for a single file or ``audio_paths`` for multiple files
+        to encode. ``mode`` selects ``'stack'`` to mix all files together or
+        ``'sequence'`` to play them one after another. ``carrierFreq`` specifies
+        the ultrasonic modulation frequency (15000-20000 Hz) and ``amp`` sets the
+        final amplitude (0-1.0).
     """
-    audio_path = params.get("audio_path")
+
     carrier = float(params.get("carrierFreq", 17500.0))
     amp = float(params.get("amp", 0.5))
+    mode = str(params.get("mode", "sequence")).lower()
+
+    # Gather list of file paths
+    audio_paths = params.get("audio_paths")
+    if audio_paths is None:
+        audio_path = params.get("audio_path")
+        audio_paths = [audio_path] if audio_path else []
+    elif isinstance(audio_paths, str):
+        audio_paths = [p.strip() for p in audio_paths.split(";") if p.strip()]
 
     carrier = np.clip(carrier, 15000.0, 20000.0)
 
     N = int(duration * sample_rate)
-    if audio_path is None:
+    if not audio_paths:
         return np.zeros((N, 2), dtype=np.float32)
 
-    try:
-        data, sr = sf.read(audio_path)
-    except Exception:
+    def load_and_modulate(path):
+        try:
+            data, sr = sf.read(path)
+        except Exception:
+            return np.array([], dtype=np.float32)
+
+        if data.ndim > 1:
+            data = np.mean(data, axis=1)
+
+        if sr != sample_rate:
+            if librosa is not None:
+                data = librosa.resample(data, orig_sr=sr, target_sr=sample_rate)
+            else:
+                t_old = np.linspace(0, len(data) / sr, num=len(data), endpoint=False)
+                t_new = np.linspace(0, len(data) / sr, num=int(len(data) * sample_rate / sr), endpoint=False)
+                data = np.interp(t_new, t_old, data)
+
+        if len(data) == 0:
+            return np.array([], dtype=np.float32)
+
+        t = np.arange(len(data)) / float(sample_rate)
+        mod = np.sin(2 * np.pi * carrier * t)
+        out = data * mod
+        max_val = np.max(np.abs(out))
+        if max_val > 0:
+            out = out / max_val
+        return out.astype(np.float32)
+
+    segments = [load_and_modulate(p) for p in audio_paths]
+    segments = [s for s in segments if len(s) > 0]
+    if not segments:
         return np.zeros((N, 2), dtype=np.float32)
 
-    if data.ndim > 1:
-        data = np.mean(data, axis=1)
-
-    if sr != sample_rate:
-        if librosa is not None:
-            data = librosa.resample(data, orig_sr=sr, target_sr=sample_rate)
-        else:
-            # fallback simple resample
-            t_old = np.linspace(0, len(data) / sr, num=len(data), endpoint=False)
-            t_new = np.linspace(0, len(data) / sr, num=int(len(data) * sample_rate / sr), endpoint=False)
-            data = np.interp(t_new, t_old, data)
-
-    if len(data) < N:
-        data = np.pad(data, (0, N - len(data)))
-    else:
-        data = data[:N]
-
-    t = np.arange(N) / float(sample_rate)
-    mod = np.sin(2 * np.pi * carrier * t)
-    out = data * mod
+    if mode == "stack":
+        out = np.zeros(N, dtype=np.float32)
+        for seg in segments:
+            repeated = np.resize(seg, N)
+            out += repeated
+        out /= len(segments)
+    else:  # sequence mode
+        out = np.zeros(N, dtype=np.float32)
+        pos = 0
+        idx = 0
+        while pos < N:
+            seg = segments[idx % len(segments)]
+            seg_len = len(seg)
+            copy_len = min(seg_len, N - pos)
+            out[pos:pos + copy_len] = seg[:copy_len]
+            pos += copy_len
+            idx += 1
 
     max_val = np.max(np.abs(out))
     if max_val > 0:


### PR DESCRIPTION
## Summary
- support multiple subliminal audio files with stack/sequence modes
- update GUI dialog to select several files and choose playback mode
- document subliminal_encode in audio README

## Testing
- `python -m py_compile src/audio/synth_functions/*.py src/audio/ui/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b1b4159c832db46d157dd7a01181