### PR TITLE
Add pause between sequential subliminals

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -147,7 +147,7 @@ Moves a tone along a geometric path using the optional `audio_engine` module.
 Combines the monaural beat voice with spatial angle modulation.  Parameters mirror those of `monaural_beat_stereo_amps` along with spatial movement controls (`spatialBeatFreq`, `spatialPhaseOffset`, `pathRadius`, etc.).
 
 ### subliminal_encode
-Encodes audio files as ultrasonic subliminals. Multiple files may be supplied via `audio_paths` and can either be mixed together (`mode="stack"`) or played one after another (`mode="sequence"`). The chosen arrangement loops for the duration of the step.
+Encodes audio files as ultrasonic subliminals. Multiple files may be supplied via `audio_paths` and can either be mixed together (`mode="stack"`) or played one after another (`mode="sequence"`). When sequencing, a one second silence is inserted between each subliminal. The chosen arrangement loops for the duration of the step.
 
 | Parameter | Default | Effect |
 |-----------|---------|-------|

--- a/src/audio/synth_functions/subliminals.py
+++ b/src/audio/synth_functions/subliminals.py
@@ -85,12 +85,18 @@ def subliminal_encode(duration, sample_rate=44100, **params):
         out = np.zeros(N, dtype=np.float32)
         pos = 0
         idx = 0
+        pause_samples = sample_rate  # one second pause between segments
         while pos < N:
             seg = segments[idx % len(segments)]
             seg_len = len(seg)
             copy_len = min(seg_len, N - pos)
             out[pos:pos + copy_len] = seg[:copy_len]
             pos += copy_len
+            if pos >= N:
+                break
+            # insert silence after each subliminal
+            pause_len = min(pause_samples, N - pos)
+            pos += pause_len  # zeros are already present in 'out'
             idx += 1
 
     max_val = np.max(np.abs(out))


### PR DESCRIPTION
## Summary
- insert silence in sequential subliminals
- document the new pause behaviour

## Testing
- `python -m py_compile src/audio/synth_functions/subliminals.py`
- `python - <<'PY'
import sys, subprocess, os
files = subprocess.check_output(['git','ls-files','*.py']).decode().splitlines()
ret=0
for f in files:
    r = subprocess.run([sys.executable,'-m','py_compile',f])
    if r.returncode!=0:
        print('Failed:',f)
        ret=1
sys.exit(ret)
PY`

------
https://chatgpt.com/codex/tasks/task_e_685232045bd0832daecae44dad2be89e