### PR TITLE
Add voice preset support

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -59,6 +59,8 @@ Available Synth Functions:
 ## GUI Overview
 ![Sequence Editor GUI with Voice Editor Dialog](https://github.com/user-attachments/assets/f39bcc5c-3505-4803-b201-8d2f05d44d3c)
 
+The voice editor dialog includes buttons to **Load Preset** and **Save Preset** so common voice configurations can be reused across projects.
+
 ### Step Tester Preview
 The editor includes a "Test Step Preview" panel for quickly auditioning a single
 step without generating the entire track. When a step is selected, the preview

--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -23,6 +23,16 @@ save_noise_params(params, "my_settings.noise")
 loaded = load_noise_params("my_settings.noise")
 ```
 
+Voice parameters from the GUI can likewise be stored as presets using `.voice` files:
+
+```python
+from audio import VoicePreset, save_voice_preset, load_voice_preset
+
+preset = VoicePreset()
+save_voice_preset(preset, "my_voice.voice")
+loaded_voice = load_voice_preset("my_voice.voice")
+```
+
 Audio can also be generated step by step by calling any synth function directly:
 
 ```

--- a/src/audio/__init__.py
+++ b/src/audio/__init__.py
@@ -1,8 +1,23 @@
-from .noise_file import NoiseParams, save_noise_params, load_noise_params, NOISE_FILE_EXTENSION
+from .noise_file import (
+    NoiseParams,
+    save_noise_params,
+    load_noise_params,
+    NOISE_FILE_EXTENSION,
+)
+from .voice_file import (
+    VoicePreset,
+    save_voice_preset,
+    load_voice_preset,
+    VOICE_FILE_EXTENSION,
+)
 
 __all__ = [
     'NoiseParams',
     'save_noise_params',
     'load_noise_params',
     'NOISE_FILE_EXTENSION',
+    'VoicePreset',
+    'save_voice_preset',
+    'load_voice_preset',
+    'VOICE_FILE_EXTENSION',
 ]

--- a/src/audio/voice_file.py
+++ b/src/audio/voice_file.py
@@ -1,0 +1,46 @@
+import json
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+VOICE_FILE_EXTENSION = ".voice"
+
+@dataclass
+class VoicePreset:
+    """Container for a voice's synthesis settings."""
+
+    synth_function_name: str = ""
+    is_transition: bool = False
+    params: Dict[str, Any] = field(default_factory=dict)
+    volume_envelope: Optional[Dict[str, Any]] = None
+    description: str = ""
+
+
+def save_voice_preset(preset: VoicePreset, filepath: str) -> None:
+    """Save ``preset`` to ``filepath`` as JSON inside a ``.voice`` file."""
+    path = Path(filepath)
+    if path.suffix != VOICE_FILE_EXTENSION:
+        path = path.with_suffix(VOICE_FILE_EXTENSION)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(asdict(preset), f, indent=2)
+
+
+def load_voice_preset(filepath: str) -> VoicePreset:
+    """Load a voice preset from ``filepath``."""
+    path = Path(filepath)
+    if not path.is_file():
+        raise FileNotFoundError(f"Voice preset not found: {filepath}")
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    preset = VoicePreset()
+    for k, v in data.items():
+        if hasattr(preset, k):
+            setattr(preset, k, v)
+    return preset
+
+__all__ = [
+    "VoicePreset",
+    "save_voice_preset",
+    "load_voice_preset",
+    "VOICE_FILE_EXTENSION",
+]


### PR DESCRIPTION
## Summary
- implement `voice_file.py` with load/save helpers
- export voice preset helpers in `audio.__init__`
- add preset management features to `VoiceEditorDialog`
- document presets in `README_Audio.md` and `src/audio/README.md`

## Testing
- `python -m py_compile src/audio/voice_file.py src/audio/__init__.py src/audio/ui/voice_editor_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_6852eb9f0820832da3a84790ae076457