### PR TITLE
Add audio timeline visualization and noise envelope support

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -200,4 +200,11 @@ If omitted, `linear` is used.
 - Use subtle panning and moderate modulation rates.
 - Crossfade between steps to avoid abrupt changes.
 
+## Timeline Visualization
+
+The helper function `audio.visualize_track_timeline()` creates a simple
+matplotlib plot showing when binaural voices, vocals, sound effects and
+background noise overlap throughout a track. Pass the same JSON structure used
+for audio generation to this function and it will display (or save) a timeline
+chart.
 

--- a/src/audio/__init__.py
+++ b/src/audio/__init__.py
@@ -10,6 +10,7 @@ from .utils.voice_file import (
     load_voice_preset,
     VOICE_FILE_EXTENSION,
 )
+from .utils.timeline_visualizer import visualize_track_timeline
 
 __all__ = [
     'NoiseParams',
@@ -20,4 +21,5 @@ __all__ = [
     'save_voice_preset',
     'load_voice_preset',
     'VOICE_FILE_EXTENSION',
+    'visualize_track_timeline',
 ]

--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -205,8 +205,11 @@ class TrackEditorApp(QMainWindow):
                 "file_path": "",
                 "amp": 0.0,
                 "pan": 0.0,
+                "start_time": 0.0,
+                "fade_in": 0.0,
+                "fade_out": 0.0,
+                "amp_envelope": [],
             },
-            "background_noise": {},
             "clips": [],
             "steps": []
         }
@@ -736,7 +739,18 @@ class TrackEditorApp(QMainWindow):
                 raise ValueError("Output filename contains invalid characters.")
             self.track_data["global_settings"]["output_filename"] = outfile
 
-            self.track_data.setdefault("background_noise", {})
+            self.track_data.setdefault(
+                "background_noise",
+                {
+                    "file_path": "",
+                    "amp": 0.0,
+                    "pan": 0.0,
+                    "start_time": 0.0,
+                    "fade_in": 0.0,
+                    "fade_out": 0.0,
+                    "amp_envelope": [],
+                },
+            )
             self.track_data["background_noise"]["file_path"] = noise_file
             try:
                 noise_amp = float(noise_amp_str) if noise_amp_str else 0.0
@@ -1053,7 +1067,18 @@ class TrackEditorApp(QMainWindow):
             loaded_data = sound_creator.load_track_from_json(filepath)
             if loaded_data and isinstance(loaded_data.get("steps"), list) and isinstance(loaded_data.get("global_settings"), dict):
                 self.track_data = loaded_data
-                self.track_data.setdefault("background_noise", {"file_path": "", "amp": 0.0, "pan": 0.0})
+                self.track_data.setdefault(
+                    "background_noise",
+                    {
+                        "file_path": "",
+                        "amp": 0.0,
+                        "pan": 0.0,
+                        "start_time": 0.0,
+                        "fade_in": 0.0,
+                        "fade_out": 0.0,
+                        "amp_envelope": [],
+                    },
+                )
                 self.track_data.setdefault("clips", [])
                 self.current_json_path = filepath
                 self.setWindowTitle(f"Binaural Track Editor (PyQt5) - {os.path.basename(filepath)}")

--- a/src/audio/requirements.txt
+++ b/src/audio/requirements.txt
@@ -5,3 +5,4 @@ pyqt5==5.15.11
 scipy==1.15.2
 slab==1.8.0
 soundfile
+matplotlib

--- a/src/audio/utils/noise_file.py
+++ b/src/audio/utils/noise_file.py
@@ -29,6 +29,10 @@ class NoiseParams:
     initial_offset: float = 0.0
     post_offset: float = 0.0
     input_audio_path: str = ""
+    start_time: float = 0.0
+    fade_in: float = 0.0
+    fade_out: float = 0.0
+    amp_envelope: List[Dict[str, Any]] = field(default_factory=list)
 
 
 def save_noise_params(params: NoiseParams, filepath: str) -> None:

--- a/src/audio/utils/timeline_visualizer.py
+++ b/src/audio/utils/timeline_visualizer.py
@@ -1,0 +1,94 @@
+import matplotlib.pyplot as plt
+from typing import Dict, List, Any, Optional
+
+
+def _estimate_track_duration(track_data: Dict[str, Any]) -> float:
+    """Return the total duration of the track based on step durations."""
+    total = 0.0
+    for step in track_data.get("steps", []):
+        try:
+            total += float(step.get("duration", 0))
+        except (TypeError, ValueError):
+            pass
+    return total
+
+
+def visualize_track_timeline(track_data: Dict[str, Any], save_path: Optional[str] = None) -> None:
+    """Visualize where different elements overlap across the track.
+
+    Parameters
+    ----------
+    track_data:
+        Dictionary describing the track (same structure as used by
+        :func:`sound_creator.generate_audio`).
+    save_path:
+        If provided, the timeline is saved to this file path instead of
+        displayed interactively.
+    """
+    categories = {
+        "binaurals": 0,
+        "vocals": 1,
+        "effects": 2,
+        "noise": 3,
+    }
+    colors = {
+        "binaurals": "tab:blue",
+        "vocals": "tab:orange",
+        "effects": "tab:green",
+        "noise": "tab:gray",
+    }
+
+    events: List[Dict[str, Any]] = []
+    current_time = 0.0
+    for step in track_data.get("steps", []):
+        step_duration = float(step.get("duration", 0))
+        voices = step.get("voices", [])
+        for voice in voices:
+            category = voice.get("category", "binaurals")
+            start = current_time
+            end = start + step_duration
+            amp = float(voice.get("params", {}).get("amp", 1.0))
+            events.append({"category": category, "start": start, "end": end, "amp": amp})
+        current_time += step_duration
+
+    for clip in track_data.get("clips", []):
+        cat = clip.get("category", "effects")
+        start = float(clip.get("start", clip.get("start_time", 0)))
+        duration = float(clip.get("duration", 0))
+        amp = float(clip.get("amp", 1.0))
+        if duration > 0:
+            events.append({"category": cat, "start": start, "end": start + duration, "amp": amp})
+
+    noise_cfg = track_data.get("background_noise", {})
+    if isinstance(noise_cfg, dict) and noise_cfg.get("file_path"):
+        start = float(noise_cfg.get("start_time", 0))
+        duration = _estimate_track_duration(track_data) - start
+        amp = float(noise_cfg.get("amp", 1.0))
+        if duration > 0:
+            events.append({"category": "noise", "start": start, "end": start + duration, "amp": amp})
+
+    if not events:
+        print("No timeline events to display.")
+        return
+
+    fig, ax = plt.subplots(figsize=(10, 3))
+    for ev in events:
+        y = categories.get(ev["category"], 0)
+        width = ev["end"] - ev["start"]
+        ax.barh(y, width, left=ev["start"], height=0.6,
+                color=colors.get(ev["category"], "tab:blue"), alpha=min(1.0, ev["amp"]))
+
+    ax.set_yticks(list(categories.values()))
+    ax.set_yticklabels(list(categories.keys()))
+    ax.set_xlabel("Time (s)")
+    ax.set_xlim(0, max(ev["end"] for ev in events))
+    ax.set_ylim(-1, len(categories))
+    ax.grid(True, axis="x", linestyle=":")
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path)
+    else:
+        plt.show()
+
+__all__ = ["visualize_track_timeline"]


### PR DESCRIPTION
## Summary
- add `timeline_visualizer` utility to plot overlapping track elements
- expose `visualize_track_timeline` through `audio` package
- extend `NoiseParams` with timing/envelope fields
- support noise start/fades and amplitude envelopes in sound creator
- set new noise defaults in the GUI
- document timeline helper
- require `matplotlib` for audio tools

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68598b0ca598832d8e25ed94f7bc9e0f