### PR TITLE
Add DAW-style timeline visualization

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -202,9 +202,10 @@ If omitted, `linear` is used.
 
 ## Timeline Visualization
 
-The helper function `audio.visualize_track_timeline()` creates a simple
-matplotlib plot showing when binaural voices, vocals, sound effects and
-background noise overlap throughout a track. Pass the same JSON structure used
-for audio generation to this function and it will display (or save) a timeline
-chart.
+The helper function `audio.visualize_track_timeline()` now renders a more
+"DAW-like" timeline view. Each track lane is drawn similar to clips in a digital
+audio workstation, making it easier to see how binaural voices, vocals, sound
+effects and background noise overlap. Pass the same JSON structure used for
+audio generation to this function and it will display (or save) the enhanced
+timeline chart.
 

--- a/src/audio/utils/timeline_visualizer.py
+++ b/src/audio/utils/timeline_visualizer.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+from matplotlib.patches import Rectangle
 from typing import Dict, List, Any, Optional
 
 
@@ -13,7 +14,10 @@ def _estimate_track_duration(track_data: Dict[str, Any]) -> float:
     return total
 
 
-def visualize_track_timeline(track_data: Dict[str, Any], save_path: Optional[str] = None) -> None:
+def visualize_track_timeline(
+    track_data: Dict[str, Any],
+    save_path: Optional[str] = None,
+) -> None:
     """Visualize where different elements overlap across the track.
 
     Parameters
@@ -48,7 +52,9 @@ def visualize_track_timeline(track_data: Dict[str, Any], save_path: Optional[str
             start = current_time
             end = start + step_duration
             amp = float(voice.get("params", {}).get("amp", 1.0))
-            events.append({"category": category, "start": start, "end": end, "amp": amp})
+            events.append(
+                {"category": category, "start": start, "end": end, "amp": amp}
+            )
         current_time += step_duration
 
     for clip in track_data.get("clips", []):
@@ -57,7 +63,14 @@ def visualize_track_timeline(track_data: Dict[str, Any], save_path: Optional[str
         duration = float(clip.get("duration", 0))
         amp = float(clip.get("amp", 1.0))
         if duration > 0:
-            events.append({"category": cat, "start": start, "end": start + duration, "amp": amp})
+            events.append(
+                {
+                    "category": cat,
+                    "start": start,
+                    "end": start + duration,
+                    "amp": amp,
+                }
+            )
 
     noise_cfg = track_data.get("background_noise", {})
     if isinstance(noise_cfg, dict) and noise_cfg.get("file_path"):
@@ -65,30 +78,55 @@ def visualize_track_timeline(track_data: Dict[str, Any], save_path: Optional[str
         duration = _estimate_track_duration(track_data) - start
         amp = float(noise_cfg.get("amp", 1.0))
         if duration > 0:
-            events.append({"category": "noise", "start": start, "end": start + duration, "amp": amp})
+            events.append(
+                {
+                    "category": "noise",
+                    "start": start,
+                    "end": start + duration,
+                    "amp": amp,
+                }
+            )
 
     if not events:
         print("No timeline events to display.")
         return
 
-    fig, ax = plt.subplots(figsize=(10, 3))
+    fig, ax = plt.subplots(figsize=(12, 4))
     for ev in events:
         y = categories.get(ev["category"], 0)
         width = ev["end"] - ev["start"]
-        ax.barh(y, width, left=ev["start"], height=0.6,
-                color=colors.get(ev["category"], "tab:blue"), alpha=min(1.0, ev["amp"]))
+        rect = Rectangle(
+            (ev["start"], y - 0.4),
+            width,
+            0.8,
+            facecolor=colors.get(ev["category"], "tab:blue"),
+            alpha=min(0.8, 0.4 + ev["amp"] * 0.6),
+        )
+        ax.add_patch(rect)
+        ax.text(
+            ev["start"] + 0.05,
+            y,
+            ev["category"],
+            va="center",
+            ha="left",
+            fontsize=8,
+            color="white",
+        )
 
+    duration = max(ev["end"] for ev in events)
     ax.set_yticks(list(categories.values()))
     ax.set_yticklabels(list(categories.keys()))
     ax.set_xlabel("Time (s)")
-    ax.set_xlim(0, max(ev["end"] for ev in events))
+    ax.set_xlim(0, duration)
     ax.set_ylim(-1, len(categories))
-    ax.grid(True, axis="x", linestyle=":")
+    ax.set_xticks([t for t in range(int(duration) + 1)])
+    ax.grid(True, axis="x", linestyle=":", alpha=0.5)
     plt.tight_layout()
 
     if save_path:
         plt.savefig(save_path)
     else:
         plt.show()
+
 
 __all__ = ["visualize_track_timeline"]


### PR DESCRIPTION
## Summary
- describe updated timeline visualization in README
- rework timeline_visualizer to draw DAW-like track lanes

## Testing
- `flake8 src/audio/utils/timeline_visualizer.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68598d307cd4832da733b3aa09f1fb86