### PR TITLE
Improve timeline visualizer details

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -207,5 +207,8 @@ The helper function `audio.visualize_track_timeline()` now renders a more
 audio workstation, making it easier to see how binaural voices, vocals, sound
 effects and background noise overlap. Pass the same JSON structure used for
 audio generation to this function and it will display (or save) the enhanced
-timeline chart.
+timeline chart.  Individual voices and overlay clips are color-coded within
+their categories and labeled using their descriptions (or filenames if no
+description is provided).  Step boundaries are shown as dashed lines so you can
+quickly identify when the track transitions from one step to the next.
 

--- a/src/audio/utils/timeline_visualizer.py
+++ b/src/audio/utils/timeline_visualizer.py
@@ -1,3 +1,4 @@
+import os
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 from typing import Dict, List, Any, Optional
@@ -35,14 +36,17 @@ def visualize_track_timeline(
         "effects": 2,
         "noise": 3,
     }
-    colors = {
-        "binaurals": "tab:blue",
-        "vocals": "tab:orange",
-        "effects": "tab:green",
-        "noise": "tab:gray",
+
+    # Base colormaps for per-category shades
+    colormaps = {
+        "binaurals": plt.cm.Blues,
+        "vocals": plt.cm.Oranges,
+        "effects": plt.cm.Greens,
+        "noise": plt.cm.Greys,
     }
 
     events: List[Dict[str, Any]] = []
+    step_boundaries: List[float] = [0.0]
     current_time = 0.0
     for step in track_data.get("steps", []):
         step_duration = float(step.get("duration", 0))
@@ -52,16 +56,25 @@ def visualize_track_timeline(
             start = current_time
             end = start + step_duration
             amp = float(voice.get("params", {}).get("amp", 1.0))
+            label = voice.get("description") or voice.get("synth_function_name", "voice")
             events.append(
-                {"category": category, "start": start, "end": end, "amp": amp}
+                {
+                    "category": category,
+                    "start": start,
+                    "end": end,
+                    "amp": amp,
+                    "label": label,
+                }
             )
         current_time += step_duration
+        step_boundaries.append(current_time)
 
     for clip in track_data.get("clips", []):
         cat = clip.get("category", "effects")
         start = float(clip.get("start", clip.get("start_time", 0)))
         duration = float(clip.get("duration", 0))
         amp = float(clip.get("amp", 1.0))
+        label = clip.get("description") or os.path.basename(clip.get("file_path", "clip"))
         if duration > 0:
             events.append(
                 {
@@ -69,6 +82,7 @@ def visualize_track_timeline(
                     "start": start,
                     "end": start + duration,
                     "amp": amp,
+                    "label": label,
                 }
             )
 
@@ -77,6 +91,7 @@ def visualize_track_timeline(
         start = float(noise_cfg.get("start_time", 0))
         duration = _estimate_track_duration(track_data) - start
         amp = float(noise_cfg.get("amp", 1.0))
+        label = os.path.basename(noise_cfg.get("file_path"))
         if duration > 0:
             events.append(
                 {
@@ -84,6 +99,7 @@ def visualize_track_timeline(
                     "start": start,
                     "end": start + duration,
                     "amp": amp,
+                    "label": label,
                 }
             )
 
@@ -91,7 +107,22 @@ def visualize_track_timeline(
         print("No timeline events to display.")
         return
 
+    # Assign distinct colors per element within each category
+    events_by_cat = {cat: [] for cat in categories.keys()}
+    for ev in events:
+        events_by_cat.setdefault(ev["category"], []).append(ev)
+
+    for cat, evs in events_by_cat.items():
+        cmap = colormaps.get(cat, plt.cm.Blues)
+        n = len(evs)
+        for i, ev in enumerate(evs):
+            frac = i / max(n - 1, 1)
+            ev["color"] = cmap(0.3 + 0.7 * frac)
+
     fig, ax = plt.subplots(figsize=(12, 4))
+    for boundary in step_boundaries:
+        ax.axvline(boundary, color="k", linestyle="--", linewidth=0.5, alpha=0.3)
+
     for ev in events:
         y = categories.get(ev["category"], 0)
         width = ev["end"] - ev["start"]
@@ -99,14 +130,14 @@ def visualize_track_timeline(
             (ev["start"], y - 0.4),
             width,
             0.8,
-            facecolor=colors.get(ev["category"], "tab:blue"),
+            facecolor=ev.get("color", "tab:blue"),
             alpha=min(0.8, 0.4 + ev["amp"] * 0.6),
         )
         ax.add_patch(rect)
         ax.text(
             ev["start"] + 0.05,
             y,
-            ev["category"],
+            ev.get("label", ev["category"]),
             va="center",
             ha="left",
             fontsize=8,


### PR DESCRIPTION
## Summary
- highlight each voice, clip and noise section on the timeline
- colour-code elements within categories and label them using descriptions
- show step boundaries and document the new behaviour in the README

## Testing
- `python -m py_compile src/audio/utils/timeline_visualizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68598f4eba88832dba46c92dca424ac9