### PR TITLE
Add collapsible controls box

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -53,6 +53,7 @@ from ui.subliminal_dialog import SubliminalDialog
 from utils.timeline_visualizer import visualize_track_timeline
 from ui.overlay_clip_dialog import OverlayClipDialog
 from ui.voice_editor_dialog import VoiceEditorDialog
+from ui.collapsible_box import CollapsibleBox
 
 # Attempt to import VoiceEditorDialog. Handle if ui/voice_editor_dialog.py is not found.
 try:
@@ -326,10 +327,10 @@ class TrackEditorApp(QMainWindow):
         self.setCentralWidget(central_widget)
         main_layout = QVBoxLayout(central_widget)
 
-        # --- Control Frame ---
-        control_groupbox = QGroupBox("Controls")
+        # --- Control Frame (Collapsible) ---
+        control_groupbox = CollapsibleBox("Controls")
         control_layout = QHBoxLayout()
-        control_groupbox.setLayout(control_layout)
+        control_groupbox.setContentLayout(control_layout)
 
         # We'll place the controls and the rest of the UI in a vertical splitter
         # so the user can resize the top controls to occupy less space.

--- a/src/audio/ui/collapsible_box.py
+++ b/src/audio/ui/collapsible_box.py
@@ -1,0 +1,30 @@
+from PyQt5.QtWidgets import QWidget, QToolButton, QVBoxLayout
+from PyQt5.QtCore import Qt
+
+class CollapsibleBox(QWidget):
+    """A simple collapsible container with a toggle button."""
+
+    def __init__(self, title: str = "", parent: QWidget = None):
+        super().__init__(parent)
+
+        self.toggle_button = QToolButton(text=title, checkable=True, checked=True)
+        self.toggle_button.setStyleSheet("QToolButton { border: none; }")
+        self.toggle_button.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.toggle_button.setArrowType(Qt.DownArrow)
+        self.toggle_button.clicked.connect(self._on_toggled)
+
+        self.content_area = QWidget()
+
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(0)
+        self._layout.addWidget(self.toggle_button)
+        self._layout.addWidget(self.content_area)
+
+    def _on_toggled(self, checked: bool):
+        self.toggle_button.setArrowType(Qt.DownArrow if checked else Qt.RightArrow)
+        self.content_area.setVisible(checked)
+
+    def setContentLayout(self, layout: QVBoxLayout):
+        """Set the layout that holds the collapsible content."""
+        self.content_area.setLayout(layout)


### PR DESCRIPTION
## Summary
- add reusable `CollapsibleBox` widget
- use `CollapsibleBox` for the controls section so it can be collapsed

## Testing
- `python -m py_compile src/audio/main.py src/audio/ui/collapsible_box.py`

------
https://chatgpt.com/codex/tasks/task_e_685997f09450832d898635d0b6fdc82b