### PR TITLE
Add QML frontend skeleton

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -33,7 +33,9 @@ from PyQt5.QtWidgets import (
     QAction,
     QProgressBar,
 )
-from PyQt5.QtCore import Qt, pyqtSlot, QTimer, QBuffer, QIODevice
+from PyQt5.QtCore import Qt, pyqtSlot, QTimer, QBuffer, QIODevice, QObject, pyqtProperty, pyqtSignal, QUrl
+from PyQt5.QtQuickWidgets import QQuickWidget
+from PyQt5.QtQml import QQmlApplicationEngine
 from PyQt5.QtGui import QIntValidator, QDoubleValidator, QFont, QPalette, QColor
 from PyQt5.QtMultimedia import (
     QAudioFormat,
@@ -137,6 +139,27 @@ except ImportError as e:
         f"Warning: Could not import 'generate_single_step_audio_segment' from 'synth_functions.sound_creator': {e}. "
         "Test step audio generation will be non-functional."
     )
+
+# Backend object exposing data to QML
+class TrackEditorBackend(QObject):
+    trackDataChanged = pyqtSignal()
+
+    def __init__(self, app):
+        super().__init__()
+        self._app = app
+
+    @pyqtProperty("QVariant", notify=trackDataChanged)
+    def trackData(self):
+        return self._app.track_data
+
+    @trackData.setter
+    def trackData(self, value):
+        self._app.track_data = value
+        self.trackDataChanged.emit()
+
+    @pyqtProperty("QVariant", constant=True)
+    def preferences(self):
+        return vars(self._app.prefs)
 
 
 # --- Main Application Class ---
@@ -306,6 +329,18 @@ class TrackEditorApp(QMainWindow):
                 QTimer.singleShot(0, lambda: self._select_last_voice_in_current_step())
             self._push_history_state()
 
+    def _setup_ui(self):
+        """Setup both widget and QML interfaces."""
+        self._setup_widget_ui()
+        qml_file = os.path.join(os.path.dirname(__file__), "qml", "main.qml")
+        if os.path.exists(qml_file):
+            self.qml_engine = QQmlApplicationEngine()
+            self.backend = TrackEditorBackend(self)
+            self.qml_engine.rootContext().setContextProperty("backend", self.backend)
+            self.qml_engine.load(QUrl.fromLocalFile(qml_file))
+            if not self.qml_engine.rootObjects():
+                print("Failed to load QML UI")
+
     def open_timeline_visualizer(self):
         """Display the timeline visualizer for the current track data."""
         try:
@@ -321,7 +356,7 @@ class TrackEditorApp(QMainWindow):
         apply_theme(app, self.prefs.theme)
         self.setStyleSheet(GLOBAL_STYLE_SHEET)
 
-    def _setup_ui(self):
+    def _setup_widget_ui(self):
         # Central Widget and Main Layout
         central_widget = QWidget()
         self.setCentralWidget(central_widget)

--- a/src/audio/qml/main.qml
+++ b/src/audio/qml/main.qml
@@ -1,0 +1,35 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+ApplicationWindow {
+    id: root
+    visible: true
+    width: 800
+    height: 600
+    title: "Track Editor QML"
+
+    property var trackData: backend.trackData
+    property var preferences: backend.preferences
+
+    Column {
+        anchors.fill: parent
+        spacing: 10
+        padding: 10
+
+        Text { text: "Track Editor - QML"; font.pixelSize: 20 }
+        Text { text: "Sample Rate: " + preferences.sample_rate }
+
+        ListView {
+            id: stepList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            model: trackData.steps
+            delegate: Rectangle {
+                width: parent.width
+                height: 30
+                color: index % 2 === 0 ? "#202020" : "#303030"
+                Text { anchors.centerIn: parent; text: "Step " + (index + 1) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `qml/main.qml` with basic list view
- expose track data and preferences through `TrackEditorBackend`
- load QML UI alongside existing widgets in `_setup_ui`

## Testing
- `python -m py_compile src/audio/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6859a12f600c832d9dfd64c96368b229