### PR TITLE
Fix missing PyQt import

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -18,6 +18,8 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QTreeView,
+    QTreeWidget,
+    QTreeWidgetItem,
     QTextEdit,
     QGroupBox,
     QSplitter,


### PR DESCRIPTION
## Summary
- import `QTreeWidget` and `QTreeWidgetItem` for use in the audio editor

## Testing
- `python -m py_compile src/audio/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859a500b148832dac548dc650d6c8f5