### PR TITLE
Fix missing QML Layout import

### DIFF
--- a/src/audio/qml/main.qml
+++ b/src/audio/qml/main.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 
 ApplicationWindow {
     id: root


### PR DESCRIPTION
## Summary
- fix QML file failing to load by importing QtQuick.Layouts

## Testing
- `QT_QPA_PLATFORM=offscreen python src/audio/main.py` *(fails: Qt platform plugin errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859c154e5c8832db36ec16cf156e814