### PR TITLE
Fix UI column headers

### DIFF
--- a/src/audio/models/models.py
+++ b/src/audio/models/models.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import QAbstractListModel, Qt, QModelIndex
+from PyQt5.QtCore import QAbstractTableModel, Qt, QModelIndex
 
-class StepModel(QAbstractListModel):
+class StepModel(QAbstractTableModel):
     """Model holding a list of step dictionaries."""
     headers = ["Duration (s)", "Description", "# Voices"]
 
@@ -58,7 +58,7 @@ class StepModel(QAbstractListModel):
         self.endResetModel()
 
 
-class VoiceModel(QAbstractListModel):
+class VoiceModel(QAbstractTableModel):
     """Model holding a list of voice dictionaries for a selected step."""
     headers = ["Synth Function", "Carrier Freq", "Transition?", "Description"]
 


### PR DESCRIPTION
## Summary
- ensure StepModel and VoiceModel inherit from `QAbstractTableModel` instead of `QAbstractListModel`
- update imports accordingly

## Testing
- `python -m py_compile src/audio/models/models.py`
- `python -m py_compile src/audio/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6859e578b108832d80c72dd25395f3ac