### PR TITLE
Fix VoiceModel beat frequency helper

### DIFF
--- a/src/audio/models/models.py
+++ b/src/audio/models/models.py
@@ -153,6 +153,49 @@ class VoiceModel(QAbstractTableModel):
                 return description
         return None
 
+    def _format_number(self, value):
+        """Return value formatted to two decimals if numeric."""
+        try:
+            return f"{float(value):.2f}"
+        except (ValueError, TypeError):
+            return str(value)
+
+    def _get_beat_frequency(self, params, is_transition):
+        """Return formatted beat frequency for display."""
+        beat_keys = [k for k in params if "beat" in k.lower() and "freq" in k.lower()]
+
+        start_keys = [k for k in beat_keys if k.lower().startswith("start")]
+        end_keys = [k for k in beat_keys if k.lower().startswith("end")]
+        normal_keys = [
+            k
+            for k in beat_keys
+            if not k.lower().startswith(("start", "end", "target"))
+        ]
+
+        if is_transition:
+            if start_keys and end_keys:
+                s_val = params.get(start_keys[0])
+                e_val = params.get(end_keys[0])
+                try:
+                    s_f = float(s_val)
+                    e_f = float(e_val)
+                    if abs(s_f - e_f) < 1e-6:
+                        return f"{s_f:.2f}"
+                    return f"{s_f:.2f}->{e_f:.2f}"
+                except (ValueError, TypeError):
+                    if s_val == e_val:
+                        return str(s_val)
+                    return f"{s_val}->{e_val}"
+            if start_keys:
+                return self._format_number(params.get(start_keys[0]))
+            if end_keys:
+                return self._format_number(params.get(end_keys[0]))
+
+        if normal_keys:
+            return self._format_number(params.get(normal_keys[0]))
+
+        return "N/A"
+
     def setData(self, index, value, role=Qt.EditRole):
         if not index.isValid() or role != Qt.EditRole:
             return False


### PR DESCRIPTION
## Summary
- copy formatting helpers from `StepModel` into `VoiceModel`
- expose `_format_number` and `_get_beat_frequency` for use when showing voices

## Testing
- `pytest -q`
- `python src/audio/main.py --help` *(fails: Could not load the Qt platform plugin "xcb")*

------
https://chatgpt.com/codex/tasks/task_e_685a472f7068832d86aaf1fa61079313