### PR TITLE
Add optional dB amplitude mode

### DIFF
--- a/src/audio/ui/frequency_tester_dialog.py
+++ b/src/audio/ui/frequency_tester_dialog.py
@@ -70,9 +70,17 @@ class FrequencyTesterDialog(QDialog):
             beat_spin.setValue(4.0)
             beat_spin.setDecimals(2)
             amp_spin = QDoubleSpinBox()
-            amp_spin.setRange(0.0, 1.0)
-            amp_spin.setSingleStep(0.05)
-            amp_spin.setValue(0.5)
+            if getattr(self.prefs, "amplitude_display_mode", "absolute") == "dB":
+                from ..utils.amp_utils import amplitude_to_db, MIN_DB
+                amp_spin.setRange(MIN_DB, 0.0)
+                amp_spin.setDecimals(1)
+                amp_spin.setSingleStep(1.0)
+                amp_spin.setSuffix(" dB")
+                amp_spin.setValue(amplitude_to_db(0.5))
+            else:
+                amp_spin.setRange(0.0, 1.0)
+                amp_spin.setSingleStep(0.05)
+                amp_spin.setValue(0.5)
             row = QWidget()
             row_layout = QHBoxLayout(row)
             row_layout.setContentsMargins(0, 0, 0, 0)
@@ -121,6 +129,9 @@ class FrequencyTesterDialog(QDialog):
                 base = vc["base"].value()
                 beat = vc["beat"].value()
                 amp = vc["amp"].value()
+                if getattr(self.prefs, "amplitude_display_mode", "absolute") == "dB":
+                    from ..utils.amp_utils import db_to_amplitude
+                    amp = db_to_amplitude(amp)
                 voice = binaural_beat(duration, sample_rate=sample_rate,
                                        ampL=amp, ampR=amp,
                                        baseFreq=base, beatFreq=beat)

--- a/src/audio/utils/amp_utils.py
+++ b/src/audio/utils/amp_utils.py
@@ -1,0 +1,17 @@
+import math
+
+MIN_DB = -60.0
+
+
+def amplitude_to_db(amplitude: float) -> float:
+    """Convert linear amplitude (0.0-1.0+) to dBFS."""
+    if amplitude <= 0:
+        return MIN_DB
+    return 20.0 * math.log10(amplitude)
+
+
+def db_to_amplitude(db: float) -> float:
+    """Convert dBFS value to linear amplitude."""
+    if db <= MIN_DB:
+        return 0.0
+    return 10 ** (db / 20.0)

--- a/src/audio/utils/preferences.py
+++ b/src/audio/utils/preferences.py
@@ -14,6 +14,7 @@ class Preferences:
     # Peak amplitude for the final exported audio (0-1.0)
     target_output_amplitude: float = 0.25
     crossfade_curve: str = "linear"
+    amplitude_display_mode: str = "absolute"  # or "dB"
 
 PREF_FILE = Path.home() / ".entrainment_prefs.json"
 


### PR DESCRIPTION
## Summary
- add amplitude conversion helpers
- allow preferences to choose amplitude display mode
- update UI dialogs to support dB or absolute amplitude

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ad143d348832db8d7d6ef5c0753ed