### PR TITLE
Add default voice configuration dialog

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -295,6 +295,10 @@ class TrackEditorApp(QMainWindow):
         pref_act.triggered.connect(self.open_preferences)
         file_menu.addAction(pref_act)
 
+        defaults_act = QAction("Configure Defaults", self)
+        defaults_act.triggered.connect(self.open_default_voice_config)
+        file_menu.addAction(defaults_act)
+
         file_menu.addSeparator()
         theme_menu = file_menu.addMenu("Theme")
         for name in sorted(THEMES.keys()):
@@ -340,6 +344,13 @@ class TrackEditorApp(QMainWindow):
             # Sync crossfade curve into current track settings
             if "global_settings" in self.track_data:
                 self.track_data["global_settings"]["crossfade_curve"] = self.prefs.crossfade_curve
+
+    def open_default_voice_config(self):
+        from ui.default_voice_dialog import DefaultVoiceDialog
+        dialog = DefaultVoiceDialog(self.prefs, self)
+        if dialog.exec_() == QDialog.Accepted:
+            self.prefs.default_voice = dialog.get_default_voice()
+            save_settings(self.prefs)
 
     def open_noise_generator(self):
         dialog = NoiseGeneratorDialog(self)

--- a/src/audio/ui/default_voice_dialog.py
+++ b/src/audio/ui/default_voice_dialog.py
@@ -1,0 +1,39 @@
+"""Dialog for configuring default voice parameters."""
+
+from PyQt5.QtWidgets import QDialog, QGroupBox
+
+from .voice_editor_dialog import VoiceEditorDialog
+from ..utils.preferences import Preferences
+
+
+class DefaultVoiceDialog(VoiceEditorDialog):
+    """Reuse :class:`VoiceEditorDialog` to edit default voice settings."""
+
+    def __init__(self, prefs: Preferences, parent=None):
+        # Create a minimal dummy app with prefs and empty track data
+        dummy_app = type("DummyApp", (), {"track_data": {"steps": []}, "prefs": prefs})
+        super().__init__(parent=parent, app_ref=dummy_app, step_index=0, voice_index=None)
+        self._prefs = prefs
+        self.setWindowTitle("Configure Default Voice")
+        self.save_button.setText("Save Defaults")
+
+        # Hide reference viewer as it is not useful here
+        for g in self.findChildren(QGroupBox):
+            if g.title().startswith("Reference Voice"):
+                g.hide()
+                break
+
+    def save_voice(self):
+        """Collect data and store into ``prefs.default_voice``."""
+        data = self._collect_data_for_main_app()
+        self._prefs.default_voice = {
+            "synth_function_name": data.get("synth_function_name", ""),
+            "is_transition": data.get("is_transition", False),
+            "params": data.get("params", {}),
+            "volume_envelope": data.get("volume_envelope"),
+        }
+        self.accept()
+
+    def get_default_voice(self):
+        return self._prefs.default_voice
+

--- a/src/audio/ui/voice_editor_dialog.py
+++ b/src/audio/ui/voice_editor_dialog.py
@@ -114,6 +114,18 @@ class VoiceEditorDialog(QDialog): # Standard class name
 
     def _load_initial_data(self):
         if self.is_new_voice:
+            prefs_voice = getattr(getattr(self.app, "prefs", None), "default_voice", None)
+            if isinstance(prefs_voice, dict) and prefs_voice.get("synth_function_name"):
+                try:
+                    self.current_voice_data = copy.deepcopy(prefs_voice)
+                    self.current_voice_data.setdefault("params", {})
+                    self.current_voice_data.setdefault("volume_envelope", None)
+                    self.current_voice_data.setdefault("description", "")
+                    self.current_voice_data.setdefault("is_transition", False)
+                    return
+                except Exception as e:
+                    print(f"Warning: failed to apply default voice from prefs: {e}")
+
             available_funcs = sorted(
                 name for name in sound_creator.SYNTH_FUNCTIONS.keys()
                 if name not in UI_EXCLUDED_FUNCTION_NAMES
@@ -121,15 +133,15 @@ class VoiceEditorDialog(QDialog): # Standard class name
             if not available_funcs:
                 available_funcs = sorted(sound_creator.SYNTH_FUNCTIONS.keys())
             first_func_name = available_funcs[0] if available_funcs else "default_sine"
-            
+
             is_trans = first_func_name.endswith("_transition")
             default_params = self._get_default_params(first_func_name, is_trans)
-            
+
             self.current_voice_data = {
                 "synth_function_name": first_func_name,
                 "is_transition": is_trans,
                 "params": default_params,
-                "volume_envelope": None,  # Or {"type": ENVELOPE_TYPE_NONE, "params": {}}
+                "volume_envelope": None,
                 "description": "",
             }
         else:

--- a/src/audio/utils/preferences.py
+++ b/src/audio/utils/preferences.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from pathlib import Path
 import json
 
@@ -16,6 +16,8 @@ class Preferences:
     crossfade_curve: str = "linear"
     amplitude_display_mode: str = "absolute"  # or "dB"
     apply_target_amplitude: bool = True
+    # Default voice configuration used when adding new voices
+    default_voice: dict = field(default_factory=dict)
 
 PREF_FILE = Path.home() / ".entrainment_prefs.json"
 


### PR DESCRIPTION
## Summary
- support saving a default voice in `Preferences`
- load this default when adding new voices
- add a `Configure Defaults` dialog derived from `VoiceEditorDialog`
- expose the new dialog from the File menu

## Testing
- `python -m compileall -q src/audio`

------
https://chatgpt.com/codex/tasks/task_e_685adc4245c4832db069eac12d3d5b0a