### PR TITLE
Enable full parameter transitions for isochronic tone

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -113,6 +113,10 @@ A tone that pulses on and off at a fixed rate using a trapezoid envelope.
 | `gapPercent` | 0.15 | Fraction of the cycle that is silent |
 | `pan` | 0 | Stereo pan location |
 
+The `_transition` variant accepts `start` and `end` forms of each parameter
+(`startAmp`/`endAmp`, `startBaseFreq`/`endBaseFreq`, etc.) to smoothly move
+between settings over the step.
+
 ### monaural_beat_stereo_amps
 Produces a monaural beat while allowing different amplitudes for the lower and upper components in each ear.
 

--- a/src/audio/ui/voice_editor_dialog.py
+++ b/src/audio/ui/voice_editor_dialog.py
@@ -1246,9 +1246,12 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('rampPercent', 0.2), ('gapPercent', 0.15), ('pan', 0.0)
                 ],
                 "transition": [
-                    ('amp', 0.5), ('startBaseFreq', 200.0), ('endBaseFreq', 200.0),
+                    ('startAmp', 0.5), ('endAmp', 0.5),
+                    ('startBaseFreq', 200.0), ('endBaseFreq', 200.0),
                     ('startBeatFreq', 4.0), ('endBeatFreq', 4.0),
-                    ('rampPercent', 0.2), ('gapPercent', 0.15), ('pan', 0.0),
+                    ('startRampPercent', 0.2), ('endRampPercent', 0.2),
+                    ('startGapPercent', 0.15), ('endGapPercent', 0.15),
+                    ('startPan', 0.0), ('endPan', 0.0),
                     ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },


### PR DESCRIPTION
## Summary
- allow amplitude, ramp, gap and pan to transition in `isochronic_tone_transition`
- expose new transition parameters in the voice editor UI
- document the `_transition` variant for isochronic tones

## Testing
- `python -m py_compile src/audio/synth_functions/isochronic_tone.py src/audio/ui/voice_editor_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_685c8fcbb52c832da53836416d10e65c