### PR TITLE
Add advanced parameters to isochronic tone

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -34,7 +34,9 @@ The `generate_audio` function orchestrates the process:
 Available Synth Functions:
 
 * `binaural_beat`: Generates classic binaural beats by presenting slightly different frequencies to the left and right channels (`baseFreq`, `beatFreq`). Pan is ignored.
-* `isochronic_tone`: Creates a pulsing tone (carrier at `baseFreq`) that turns on and off at the `beatFreq`, using a configurable trapezoidal envelope (`rampPercent`, `gapPercent`). Can be panned (`pan`).
+* `isochronic_tone`: Pulsing tone with a trapezoidal envelope. Supports the same
+  modulation parameters as `binaural_beat` (minus the glitch options) in
+  addition to `rampPercent`, `gapPercent`, and optional `pan`.
 * `basic_am`: Simple Amplitude Modulation where a carrier sine wave (`carrierFreq`) is modulated by an LFO (`modFreq`, `modDepth`).
 * `fsam_filter_bank`: Frequency-Selective Amplitude Modulation. Filters a noise source (white, pink, or brown) into a specific band (`filterCenterFreq`, `filterRQ`) and modulates only that band with an LFO (`modFreq`, `modDepth`), mixing it back with the rest of the noise.
 * `rhythmic_waveshaping`: Modulates the amplitude of a carrier (`carrierFreq`) with an LFO (`modFreq`, `modDepth`) before applying tanh waveshaping (`shapeAmount`).

--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -102,16 +102,17 @@ Creates the classic binaural beat illusion by playing two close frequencies.
 | `phaseOscRange` | 0 | Amount of phase modulation |
 
 ### isochronic_tone
-A tone that pulses on and off at a fixed rate using a trapezoid envelope.
+A pulsing tone using a trapezoid envelope.  This voice now accepts the same
+set of modulation parameters as **`binaural_beat`** (excluding the glitch
+options) while retaining the isochronic-specific envelope controls.
+
+Additional parameters:
 
 | Parameter | Default | Effect |
 |-----------|---------|-------|
-| `amp` | 0.5 | Output level |
-| `baseFreq` | 200 | Frequency of the tone |
-| `beatFreq` | 4 | Pulse repetition rate |
 | `rampPercent` | 0.2 | Portion of each pulse used for fade in/out |
 | `gapPercent` | 0.15 | Fraction of the cycle that is silent |
-| `pan` | 0 | Stereo pan location |
+| `pan` | 0 | Extra stereo pan applied after modulation |
 
 ### monaural_beat_stereo_amps
 Produces a monaural beat while allowing different amplitudes for the lower and upper components in each ear.

--- a/src/audio/synth_functions/isochronic_tone.py
+++ b/src/audio/synth_functions/isochronic_tone.py
@@ -5,29 +5,71 @@ from .common import pan2, trapezoid_envelope_vectorized, calculate_transition_al
 
 
 def isochronic_tone(duration, sample_rate=44100, **params):
-    amp = float(params.get('amp', 0.5))
+    """Generate an isochronic tone with extended modulation options."""
+
+    # Legacy amplitude/pan parameters
+    base_amp = float(params.get('amp', 0.5))
+    pan = float(params.get('pan', 0.0))
+
+    # Extended parameters matching ``binaural_beat`` (glitch parameters omitted)
+    ampL = float(params.get('ampL', base_amp))
+    ampR = float(params.get('ampR', base_amp))
     baseFreq = float(params.get('baseFreq', 200.0))
-    beatFreq = float(params.get('beatFreq', 4.0)) # Note: For isochronic, this is the pulse rate
-    rampPercent = float(params.get('rampPercent', 0.2)) # Duration of ramp up/down as % of pulse ON time
-    gapPercent = float(params.get('gapPercent', 0.15)) # Duration of silence as % of total cycle time
-    pan = float(params.get('pan', 0.0)) # Panning (-1 L, 0 C, 1 R)
+    beatFreq = float(params.get('beatFreq', 4.0))  # Pulse rate
+    force_mono = bool(params.get('forceMono', False))
+    startPhaseL = float(params.get('startPhaseL', 0.0))
+    startPhaseR = float(params.get('startPhaseR', 0.0))
+    ampOscDepthL = float(params.get('ampOscDepthL', 0.0))
+    ampOscFreqL = float(params.get('ampOscFreqL', 0.0))
+    ampOscDepthR = float(params.get('ampOscDepthR', 0.0))
+    ampOscFreqR = float(params.get('ampOscFreqR', 0.0))
+    freqOscRangeL = float(params.get('freqOscRangeL', 0.0))
+    freqOscFreqL = float(params.get('freqOscFreqL', 0.0))
+    freqOscRangeR = float(params.get('freqOscRangeR', 0.0))
+    freqOscFreqR = float(params.get('freqOscFreqR', 0.0))
+    ampOscPhaseOffsetL = float(params.get('ampOscPhaseOffsetL', 0.0))
+    ampOscPhaseOffsetR = float(params.get('ampOscPhaseOffsetR', 0.0))
+    phaseOscFreq = float(params.get('phaseOscFreq', 0.0))
+    phaseOscRange = float(params.get('phaseOscRange', 0.0))
+
+    rampPercent = float(params.get('rampPercent', 0.2))
+    gapPercent = float(params.get('gapPercent', 0.15))
 
     N = int(sample_rate * duration)
     if N <= 0:
         return np.zeros((0, 2))
 
-    t_abs = np.linspace(0, duration, N, endpoint=False)
+    t = np.linspace(0, duration, N, endpoint=False)
+    dt = 1.0 / sample_rate if N > 1 else duration
 
-    # --- Carrier Wave ---
-    instantaneous_carrier_freq = np.maximum(0.0, baseFreq) # Ensure non-negative
-    carrier_freq_array = np.full(N, instantaneous_carrier_freq)
+    # --- Instantaneous carrier frequencies (with vibrato) ---
+    vibL = (freqOscRangeL / 2.0) * np.sin(2 * np.pi * freqOscFreqL * t)
+    vibR = (freqOscRangeR / 2.0) * np.sin(2 * np.pi * freqOscFreqR * t)
 
-    if N > 1: dt = np.diff(t_abs, prepend=t_abs[0])
-    elif N == 1: dt = np.array([duration])
-    else: dt = np.array([])
+    inst_freq_L = baseFreq + vibL
+    inst_freq_R = baseFreq + vibR
 
-    carrier_phase = np.cumsum(2 * np.pi * carrier_freq_array * dt)
-    carrier = np.sin(carrier_phase)
+    if force_mono:
+        inst_freq_L[:] = baseFreq
+        inst_freq_R[:] = baseFreq
+
+    inst_freq_L = np.maximum(0.0, inst_freq_L)
+    inst_freq_R = np.maximum(0.0, inst_freq_R)
+
+    # --- Phase accumulation ---
+    phase_inc_L = 2 * np.pi * inst_freq_L * dt
+    phase_inc_R = 2 * np.pi * inst_freq_R * dt
+    phase_L = startPhaseL + np.cumsum(np.concatenate(([0.0], phase_inc_L[:-1])))
+    phase_R = startPhaseR + np.cumsum(np.concatenate(([0.0], phase_inc_R[:-1])))
+
+    # --- Phase modulation ---
+    if phaseOscFreq != 0.0 or phaseOscRange != 0.0:
+        dphi = (phaseOscRange / 2.0) * np.sin(2 * np.pi * phaseOscFreq * t)
+        phase_L -= dphi
+        phase_R += dphi
+
+    carrier_L = np.sin(phase_L)
+    carrier_R = np.sin(phase_R)
 
     # --- Isochronic Envelope ---
     instantaneous_beat_freq = np.maximum(0.0, beatFreq) # Pulse rate, ensure non-negative
@@ -53,14 +95,20 @@ def isochronic_tone(duration, sample_rate=44100, **params):
     # Generate the trapezoid envelope based on time within cycle
     iso_env = trapezoid_envelope_vectorized(t_in_cycle, cycle_len_array, rampPercent, gapPercent)
 
-    # Apply envelope to carrier
-    mono_signal = carrier * iso_env
+    # Apply envelope to carriers
+    env_amp_L = 1.0 - ampOscDepthL * (0.5 * (1.0 + np.sin(2 * np.pi * ampOscFreqL * t + ampOscPhaseOffsetL)))
+    env_amp_R = 1.0 - ampOscDepthR * (0.5 * (1.0 + np.sin(2 * np.pi * ampOscFreqR * t + ampOscPhaseOffsetR)))
 
-    # Apply overall amplitude
-    output_mono = mono_signal * amp
+    left = carrier_L * iso_env * env_amp_L * ampL
+    right = carrier_R * iso_env * env_amp_R * ampR
 
-    # Pan the result
-    audio = pan2(output_mono, pan=pan)
+    if pan != 0.0:
+        # Apply additional panning if requested
+        stereo = np.column_stack((left, right))
+        stereo = pan2(stereo.mean(axis=1), pan=pan)
+        left, right = stereo[:, 0], stereo[:, 1]
+
+    audio = np.column_stack((left, right))
 
     # Note: Volume envelope (like ADSR/Linen) is applied *within* generate_voice_audio if specified there.
     # The trapezoid envelope is inherent to the isochronic tone generation itself.
@@ -69,39 +117,109 @@ def isochronic_tone(duration, sample_rate=44100, **params):
 
 
 def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
-    amp = float(params.get('amp', 0.5)) # Constant amplitude for the voice
+    """Transitioning version of :func:`isochronic_tone`."""
+
+    base_amp = float(params.get('amp', 0.5))
+    startAmpL = float(params.get('startAmpL', params.get('ampL', base_amp)))
+    endAmpL = float(params.get('endAmpL', startAmpL))
+    startAmpR = float(params.get('startAmpR', params.get('ampR', base_amp)))
+    endAmpR = float(params.get('endAmpR', startAmpR))
+
     startBaseFreq = float(params.get('startBaseFreq', 200.0))
-    endBaseFreq = float(params.get('endBaseFreq', startBaseFreq)) # Default end to start
-    startBeatFreq = float(params.get('startBeatFreq', 4.0)) # Start pulse rate
-    endBeatFreq = float(params.get('endBeatFreq', startBeatFreq)) # End pulse rate
-    rampPercent = float(params.get('rampPercent', 0.2)) # Constant ramp %
-    gapPercent = float(params.get('gapPercent', 0.15)) # Constant gap %
-    pan = float(params.get('pan', 0.0)) # Constant panning
+    endBaseFreq = float(params.get('endBaseFreq', startBaseFreq))
+    startBeatFreq = float(params.get('startBeatFreq', 4.0))
+    endBeatFreq = float(params.get('endBeatFreq', startBeatFreq))
+
+    startForceMono = float(params.get('startForceMono', params.get('forceMono', 0.0)))
+    endForceMono = float(params.get('endForceMono', startForceMono))
+    startStartPhaseL = float(params.get('startStartPhaseL', params.get('startPhaseL', 0.0)))
+    endStartPhaseL = float(params.get('endStartPhaseL', startStartPhaseL))
+    startStartPhaseR = float(params.get('startStartPhaseR', params.get('startPhaseR', 0.0)))
+    endStartPhaseR = float(params.get('endStartPhaseR', startStartPhaseR))
+
+    startAODL = float(params.get('startAmpOscDepthL', params.get('ampOscDepthL', 0.0)))
+    endAODL = float(params.get('endAmpOscDepthL', startAODL))
+    startAOFL = float(params.get('startAmpOscFreqL', params.get('ampOscFreqL', 0.0)))
+    endAOFL = float(params.get('endAmpOscFreqL', startAOFL))
+    startAODR = float(params.get('startAmpOscDepthR', params.get('ampOscDepthR', 0.0)))
+    endAODR = float(params.get('endAmpOscDepthR', startAODR))
+    startAOFR = float(params.get('startAmpOscFreqR', params.get('ampOscFreqR', 0.0)))
+    endAOFR = float(params.get('endAmpOscFreqR', startAOFR))
+    startAmpOscPhaseOffsetL = float(params.get('startAmpOscPhaseOffsetL', params.get('ampOscPhaseOffsetL', 0.0)))
+    endAmpOscPhaseOffsetL = float(params.get('endAmpOscPhaseOffsetL', startAmpOscPhaseOffsetL))
+    startAmpOscPhaseOffsetR = float(params.get('startAmpOscPhaseOffsetR', params.get('ampOscPhaseOffsetR', 0.0)))
+    endAmpOscPhaseOffsetR = float(params.get('endAmpOscPhaseOffsetR', startAmpOscPhaseOffsetR))
+
+    startFORL = float(params.get('startFreqOscRangeL', params.get('freqOscRangeL', 0.0)))
+    endFORL = float(params.get('endFreqOscRangeL', startFORL))
+    startFOFL = float(params.get('startFreqOscFreqL', params.get('freqOscFreqL', 0.0)))
+    endFOFL = float(params.get('endFreqOscFreqL', startFOFL))
+    startFORR = float(params.get('startFreqOscRangeR', params.get('freqOscRangeR', 0.0)))
+    endFORR = float(params.get('endFreqOscRangeR', startFORR))
+    startFOFR = float(params.get('startFreqOscFreqR', params.get('freqOscFreqR', 0.0)))
+    endFOFR = float(params.get('endFreqOscFreqR', startFOFR))
+
+    startPOF = float(params.get('startPhaseOscFreq', params.get('phaseOscFreq', 0.0)))
+    endPOF = float(params.get('endPhaseOscFreq', startPOF))
+    startPOR = float(params.get('startPhaseOscRange', params.get('phaseOscRange', 0.0)))
+    endPOR = float(params.get('endPhaseOscRange', startPOR))
+
+    rampPercent = float(params.get('rampPercent', 0.2))
+    gapPercent = float(params.get('gapPercent', 0.15))
+    pan = float(params.get('pan', 0.0))
 
     N = int(sample_rate * duration)
     if N <= 0:
         return np.zeros((0, 2))
 
-    t_abs = np.linspace(0, duration, N, endpoint=False)
+    t = np.linspace(0, duration, N, endpoint=False)
 
     curve = params.get('transition_curve', 'linear')
     alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
 
     # --- Interpolate Frequencies ---
     base_freq_array = startBaseFreq + (endBaseFreq - startBaseFreq) * alpha
-    beat_freq_array = startBeatFreq + (endBeatFreq - startBeatFreq) * alpha  # Pulse rate array
+    beat_freq_array = startBeatFreq + (endBeatFreq - startBeatFreq) * alpha
 
     # Ensure frequencies are non-negative
     instantaneous_carrier_freq_array = np.maximum(0.0, base_freq_array)
     instantaneous_beat_freq_array = np.maximum(0.0, beat_freq_array)
 
-    # --- Carrier Wave (Time-Varying Frequency) ---
-    if N > 1: dt = np.diff(t_abs, prepend=t_abs[0])
-    elif N == 1: dt = np.array([duration])
-    else: dt = np.array([])
+    # --- Carrier Wave (Time-Varying Frequency with vibrato) ---
+    dt = 1.0 / sample_rate if N > 1 else duration
 
-    carrier_phase = np.cumsum(2 * np.pi * instantaneous_carrier_freq_array * dt)
-    carrier = np.sin(carrier_phase)
+    vibL = (startFORL + (endFORL - startFORL) * alpha) / 2.0
+    vibL *= np.sin(2 * np.pi * (startFOFL + (endFOFL - startFOFL) * alpha) * t)
+    vibR = (startFORR + (endFORR - startFORR) * alpha) / 2.0
+    vibR *= np.sin(2 * np.pi * (startFOFR + (endFOFR - startFOFR) * alpha) * t)
+
+    inst_freq_L = instantaneous_carrier_freq_array + vibL
+    inst_freq_R = instantaneous_carrier_freq_array + vibR
+
+    force_mono_arr = startForceMono + (endForceMono - startForceMono) * alpha
+    mono_mask = force_mono_arr > 0.5
+    inst_freq_L[mono_mask] = instantaneous_carrier_freq_array[mono_mask]
+    inst_freq_R[mono_mask] = instantaneous_carrier_freq_array[mono_mask]
+
+    inst_freq_L = np.maximum(0.0, inst_freq_L)
+    inst_freq_R = np.maximum(0.0, inst_freq_R)
+
+    phase_inc_L = 2 * np.pi * inst_freq_L * dt
+    phase_inc_R = 2 * np.pi * inst_freq_R * dt
+    phase_L = (startStartPhaseL + (endStartPhaseL - startStartPhaseL) * alpha)
+    phase_R = (startStartPhaseR + (endStartPhaseR - startStartPhaseR) * alpha)
+    phase_L = phase_L + np.cumsum(np.concatenate(([0.0], phase_inc_L[:-1])))
+    phase_R = phase_R + np.cumsum(np.concatenate(([0.0], phase_inc_R[:-1])))
+
+    pOF_arr = startPOF + (endPOF - startPOF) * alpha
+    pOR_arr = startPOR + (endPOR - startPOR) * alpha
+    if np.any(pOF_arr != 0.0) or np.any(pOR_arr != 0.0):
+        dphi = (pOR_arr / 2.0) * np.sin(2 * np.pi * pOF_arr * t)
+        phase_L -= dphi
+        phase_R += dphi
+
+    carrier_L = np.sin(phase_L)
+    carrier_R = np.sin(phase_R)
 
     # --- Isochronic Envelope (Time-Varying Pulse Rate) ---
     # Calculate time-varying cycle length
@@ -118,17 +236,30 @@ def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, 
     t_in_cycle = np.mod(beat_phase_cycles, 1.0) * cycle_len_array
     t_in_cycle[~valid_beat_mask] = 0.0
 
-    # Generate the trapezoid envelope (using constant ramp/gap percentages but time-varying cycle length)
+    # Generate the trapezoid envelope
     iso_env = trapezoid_envelope_vectorized(t_in_cycle, cycle_len_array, rampPercent, gapPercent)
 
-    # Apply envelope to carrier
-    mono_signal = carrier * iso_env
+    env_amp_L = 1.0 - (startAODL + (endAODL - startAODL) * alpha) * (
+        0.5 * (1.0 + np.sin(2 * np.pi * (startAOFL + (endAOFL - startAOFL) * alpha) * t +
+                           (startAmpOscPhaseOffsetL + (endAmpOscPhaseOffsetL - startAmpOscPhaseOffsetL) * alpha)))
+    )
+    env_amp_R = 1.0 - (startAODR + (endAODR - startAODR) * alpha) * (
+        0.5 * (1.0 + np.sin(2 * np.pi * (startAOFR + (endAOFR - startAOFR) * alpha) * t +
+                           (startAmpOscPhaseOffsetR + (endAmpOscPhaseOffsetR - startAmpOscPhaseOffsetR) * alpha)))
+    )
 
-    # Apply overall amplitude
-    output_mono = mono_signal * amp
+    ampL_arr = startAmpL + (endAmpL - startAmpL) * alpha
+    ampR_arr = startAmpR + (endAmpR - startAmpR) * alpha
 
-    # Pan the result
-    audio = pan2(output_mono, pan=pan)
+    left = carrier_L * iso_env * env_amp_L * ampL_arr
+    right = carrier_R * iso_env * env_amp_R * ampR_arr
+
+    if pan != 0.0:
+        stereo = np.column_stack((left, right))
+        stereo = pan2(stereo.mean(axis=1), pan=pan)
+        left, right = stereo[:, 0], stereo[:, 1]
+
+    audio = np.column_stack((left, right))
 
     # Note: Volume envelope (like ADSR/Linen) is applied *within* generate_voice_audio if specified there.
 


### PR DESCRIPTION
## Summary
- expand `isochronic_tone` and `isochronic_tone_transition` to accept the same
  modulation parameters as `binaural_beat` (glitch options excluded)
- update audio documentation for the new capabilities

## Testing
- `python -m py_compile src/audio/synth_functions/isochronic_tone.py`

------
https://chatgpt.com/codex/tasks/task_e_685c904ab8e0832dbb558bd513c4fbcd