### PR TITLE
Update Isochronic Tone parameter listing

### DIFF
--- a/src/audio/ui/voice_editor_dialog.py
+++ b/src/audio/ui/voice_editor_dialog.py
@@ -1240,15 +1240,39 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
-            "isochronic_tone": { # This is an example, ensure it's correct
+            "isochronic_tone": {
                 "standard": [
-                    ('amp', 0.5), ('baseFreq', 200.0), ('beatFreq', 4.0),
+                    ('amp', 0.5), ('ampL', 0.5), ('ampR', 0.5),
+                    ('baseFreq', 200.0), ('beatFreq', 4.0),
+                    ('forceMono', False), ('startPhaseL', 0.0), ('startPhaseR', 0.0),
+                    ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0),
+                    ('ampOscDepthR', 0.0), ('ampOscFreqR', 0.0),
+                    ('freqOscRangeL', 0.0), ('freqOscFreqL', 0.0),
+                    ('freqOscRangeR', 0.0), ('freqOscFreqR', 0.0),
+                    ('ampOscPhaseOffsetL', 0.0), ('ampOscPhaseOffsetR', 0.0),
+                    ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0),
                     ('rampPercent', 0.2), ('gapPercent', 0.15), ('pan', 0.0)
                 ],
                 "transition": [
-                    ('startAmp', 0.5), ('endAmp', 0.5),
+                    ('startAmpL', 0.5), ('endAmpL', 0.5),
+                    ('startAmpR', 0.5), ('endAmpR', 0.5),
                     ('startBaseFreq', 200.0), ('endBaseFreq', 200.0),
                     ('startBeatFreq', 4.0), ('endBeatFreq', 4.0),
+                    ('startForceMono', 0.0), ('endForceMono', 0.0),
+                    ('startStartPhaseL', 0.0), ('endStartPhaseL', 0.0),
+                    ('startStartPhaseR', 0.0), ('endStartPhaseR', 0.0),
+                    ('startAmpOscDepthL', 0.0), ('endAmpOscDepthL', 0.0),
+                    ('startAmpOscFreqL', 0.0), ('endAmpOscFreqL', 0.0),
+                    ('startAmpOscDepthR', 0.0), ('endAmpOscDepthR', 0.0),
+                    ('startAmpOscFreqR', 0.0), ('endAmpOscFreqR', 0.0),
+                    ('startFreqOscRangeL', 0.0), ('endFreqOscRangeL', 0.0),
+                    ('startFreqOscFreqL', 0.0), ('endFreqOscFreqL', 0.0),
+                    ('startFreqOscRangeR', 0.0), ('endFreqOscRangeR', 0.0),
+                    ('startFreqOscFreqR', 0.0), ('endFreqOscFreqR', 0.0),
+                    ('startAmpOscPhaseOffsetL', 0.0), ('endAmpOscPhaseOffsetL', 0.0),
+                    ('startAmpOscPhaseOffsetR', 0.0), ('endAmpOscPhaseOffsetR', 0.0),
+                    ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0),
+                    ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0),
                     ('startRampPercent', 0.2), ('endRampPercent', 0.2),
                     ('startGapPercent', 0.15), ('endGapPercent', 0.15),
                     ('startPan', 0.0), ('endPan', 0.0),


### PR DESCRIPTION
## Summary
- add missing isochronic tone parameters to the GUI parameter dictionary

## Testing
- `python -m py_compile src/audio/ui/voice_editor_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_685c97495eb4832da5d15f8469f8e2a7