### PR TITLE
Add Rust realtime backend skeleton

### DIFF
--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "realtime_backend"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "realtime_backend"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21.0", features = ["extension-module"] }
+cpal = "0.15.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rustfft = "6.1"
+biquad = "0.4"
+rand = "0.8"
+crossbeam = "0.8"
+parking_lot = "0.12"
+once_cell = "1.19"
+

--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -1,0 +1,22 @@
+# Realtime Backend (Work in progress)
+
+This crate provides the initial structure for a Rust-based audio generation engine.
+It mirrors the JSON track format used by the Python implementation and exposes a
+minimal PyO3 interface for starting and stopping playback.
+
+Implemented components:
+
+- **Project setup** with Cargo, PyO3, CPAL and DSP-related dependencies.
+- **Track models** mirroring the Python data structures.
+- **Basic DSP utilities** (noise generators, sine wave, ADSR, pan).
+- **Skeleton scheduler** capable of processing blocks and advancing steps.
+- **Audio thread bootstrap** using CPAL (currently loops forever).
+- **Python bindings** with `start_stream` and `stop_stream` functions.
+
+Remaining tasks (see `REALTIME_BACKEND_PLAN.md` for full roadmap):
+
+- Proper voice implementations for each synth function.
+- Crossfade and transition handling in `TrackScheduler`.
+- A robust mechanism to stop the audio thread from Python.
+- Unit tests comparing DSP routines with the Python version.
+- Integration with the rest of the application via a high-level Python wrapper.

--- a/src/audio/realtime_backend/src/audio_io.rs
+++ b/src/audio/realtime_backend/src/audio_io.rs
@@ -1,0 +1,39 @@
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{SampleFormat, StreamConfig};
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+use crate::scheduler::TrackScheduler;
+
+pub fn run_audio_stream(scheduler: Arc<Mutex<TrackScheduler>>) {
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .expect("no output device available");
+    let supported_config = device.default_output_config().expect("no default config");
+    let sample_format = supported_config.sample_format();
+    let config: StreamConfig = supported_config.into();
+
+    let audio_callback = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+        let mut scheduler = scheduler.lock();
+        scheduler.process_block(data);
+    };
+    let err_fn = |err| eprintln!("stream error: {err}");
+
+    let stream = match sample_format {
+        SampleFormat::F32 => device
+            .build_output_stream(&config, audio_callback, err_fn, None)
+            .unwrap(),
+        _ => panic!("Unsupported sample format"),
+    };
+    stream.play().unwrap();
+
+    // Keep the stream alive until the thread is killed
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+pub fn stop_audio_stream() {
+    // TODO: Implement a mechanism to stop the audio thread
+}

--- a/src/audio/realtime_backend/src/dsp/mod.rs
+++ b/src/audio/realtime_backend/src/dsp/mod.rs
@@ -1,0 +1,83 @@
+use rand::Rng;
+
+pub fn generate_pink_noise_samples(n_samples: usize) -> Vec<f32> {
+    // Simple approximation of pink noise using Voss-McCartney algorithm
+    let mut rng = rand::thread_rng();
+    let mut b0 = 0.0f32;
+    let mut b1 = 0.0f32;
+    let mut b2 = 0.0f32;
+    let mut b3 = 0.0f32;
+    let mut b4 = 0.0f32;
+    let mut b5 = 0.0f32;
+    let mut out = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
+        let w = rng.gen::<f32>();
+        b0 = 0.99886 * b0 + w * 0.0555179;
+        b1 = 0.99332 * b1 + w * 0.0750759;
+        b2 = 0.96900 * b2 + w * 0.1538520;
+        b3 = 0.86650 * b3 + w * 0.3104856;
+        b4 = 0.55000 * b4 + w * 0.5329522;
+        b5 = -0.7616 * b5 - w * 0.0168980;
+        out.push((b0 + b1 + b2 + b3 + b4 + b5) * 0.11);
+    }
+    out
+}
+
+pub fn generate_brown_noise_samples(n_samples: usize) -> Vec<f32> {
+    let mut rng = rand::thread_rng();
+    let mut cumulative = 0.0f32;
+    let mut out = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
+        cumulative += rng.gen::<f32>() - 0.5;
+        out.push(cumulative);
+    }
+    let max_abs = out.iter().cloned().fold(0.0f32, |a, b| a.max(b.abs()));
+    if max_abs > 0.0 {
+        for v in &mut out {
+            *v /= max_abs;
+        }
+    }
+    out
+}
+
+pub fn sine_wave(freq: f32, t: f32, phase: f32) -> f32 {
+    (2.0 * std::f32::consts::PI * freq * t + phase).sin()
+}
+
+pub fn adsr_envelope(t: &[f32], attack: f32, decay: f32, sustain_level: f32, release: f32) -> Vec<f32> {
+    let total_samples = t.len();
+    if total_samples == 0 {
+        return Vec::new();
+    }
+    let duration = t[total_samples - 1] - t[0] + if total_samples > 1 { t[1] - t[0] } else { 0.0 };
+    let sr = total_samples as f32 / duration;
+    let attack_samples = (attack * sr) as usize;
+    let decay_samples = (decay * sr) as usize;
+    let release_samples = (release * sr) as usize;
+    let sustain_samples = total_samples.saturating_sub(attack_samples + decay_samples + release_samples);
+    let mut env = Vec::with_capacity(total_samples);
+    for i in 0..attack_samples {
+        env.push(i as f32 / attack_samples as f32);
+    }
+    for i in 0..decay_samples {
+        let level = 1.0 - (1.0 - sustain_level) * (i as f32 / decay_samples as f32);
+        env.push(level);
+    }
+    for _ in 0..sustain_samples {
+        env.push(sustain_level);
+    }
+    for i in 0..release_samples {
+        let level = sustain_level * (1.0 - (i as f32 / release_samples as f32));
+        env.push(level);
+    }
+    env.truncate(total_samples);
+    env
+}
+
+pub fn pan2(signal: f32, pan: f32) -> (f32, f32) {
+    let pan = pan.clamp(-1.0, 1.0);
+    let angle = (pan + 1.0) * std::f32::consts::FRAC_PI_4;
+    let left = angle.cos() * signal;
+    let right = angle.sin() * signal;
+    (left, right)
+}

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -1,0 +1,39 @@
+mod audio_io;
+mod dsp;
+mod models;
+mod scheduler;
+
+use models::TrackData;
+use pyo3::prelude::*;
+use scheduler::TrackScheduler;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use once_cell::sync::Lazy;
+
+static ENGINE_STATE: Lazy<Mutex<Option<Arc<Mutex<TrackScheduler>>>>> = Lazy::new(|| Mutex::new(None));
+
+#[pyfunction]
+fn start_stream(track_json_str: String) -> PyResult<()> {
+    let track_data: TrackData = serde_json::from_str(&track_json_str)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+    let scheduler = Arc::new(Mutex::new(TrackScheduler::new(track_data)));
+    *ENGINE_STATE.lock() = Some(scheduler.clone());
+    std::thread::spawn(move || {
+        audio_io::run_audio_stream(scheduler);
+    });
+    Ok(())
+}
+
+#[pyfunction]
+fn stop_stream() -> PyResult<()> {
+    *ENGINE_STATE.lock() = None;
+    audio_io::stop_audio_stream();
+    Ok(())
+}
+
+#[pymodule]
+fn realtime_backend(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(start_stream, m)?)?;
+    m.add_function(wrap_pyfunction!(stop_stream, m)?)?;
+    Ok(())
+}

--- a/src/audio/realtime_backend/src/models.rs
+++ b/src/audio/realtime_backend/src/models.rs
@@ -1,0 +1,38 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct VolumeEnvelope {
+    #[serde(rename = "type")]
+    pub envelope_type: String,
+    pub params: HashMap<String, f64>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct VoiceData {
+    pub synth_function_name: String,
+    pub params: HashMap<String, serde_json::Value>,
+    pub volume_envelope: Option<VolumeEnvelope>,
+    #[serde(default)]
+    pub is_transition: bool,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct StepData {
+    pub duration: f64,
+    pub voices: Vec<VoiceData>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct GlobalSettings {
+    pub sample_rate: u32,
+    pub crossfade_duration: f64,
+    pub crossfade_curve: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct TrackData {
+    pub global_settings: GlobalSettings,
+    pub steps: Vec<StepData>,
+    // TODO: Add background noise and clips when implemented
+}

--- a/src/audio/realtime_backend/src/scheduler.rs
+++ b/src/audio/realtime_backend/src/scheduler.rs
@@ -1,0 +1,50 @@
+use crate::dsp::{sine_wave, adsr_envelope};
+use crate::models::{TrackData, StepData, VoiceData};
+
+pub trait Voice: Send + Sync {
+    fn process(&mut self, output: &mut [f32]);
+    fn is_finished(&self) -> bool;
+}
+
+pub struct TrackScheduler {
+    pub track: TrackData,
+    pub current_sample: usize,
+    pub current_step: usize,
+    pub active_voices: Vec<Box<dyn Voice>>,
+    pub sample_rate: f32,
+}
+
+impl TrackScheduler {
+    pub fn new(track: TrackData) -> Self {
+        let sample_rate = track.global_settings.sample_rate as f32;
+        Self {
+            track,
+            current_sample: 0,
+            current_step: 0,
+            active_voices: Vec::new(),
+            sample_rate,
+        }
+    }
+
+    pub fn process_block(&mut self, buffer: &mut [f32]) {
+        for sample in buffer.iter_mut() {
+            *sample = 0.0;
+        }
+        if self.current_step >= self.track.steps.len() {
+            return;
+        }
+        let step = &self.track.steps[self.current_step];
+        // TODO instantiate voices at step boundaries
+        for voice in &mut self.active_voices {
+            voice.process(buffer);
+        }
+        // TODO crossfade and step transition logic
+        self.current_sample += buffer.len();
+        if self.current_sample as f32 / self.sample_rate >= step.duration as f32 {
+            self.current_step += 1;
+            self.current_sample = 0;
+            // TODO spawn voices for new step
+            self.active_voices.retain(|v| !v.is_finished());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- initialize `src/audio/realtime_backend` Rust crate
- add core models mirroring Python track structures
- implement basic DSP utilities and scheduler skeleton
- start/stop functions exposed via PyO3
- document current implementation and TODOs

## Testing
- `cargo build` in `src/audio/realtime_backend`
- `cargo test` in `src/audio/realtime_backend`


------
https://chatgpt.com/codex/tasks/task_e_6861e6afa6c4832da4d0e4d7fa080d50