### PR TITLE
Add WebAssembly DSP guide

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -74,3 +74,6 @@ duration adapts to the step length:
 
 This behaviour ensures that very long steps do not delay the preview yet short
 steps can still be heard in full.
+
+### WebAssembly DSP Backend
+For browser-based projects you can compile the Rust realtime backend to WebAssembly. See [src/audio/realtime_backend/WASM_GUIDE.md](src/audio/realtime_backend/WASM_GUIDE.md) for build and usage steps.

--- a/src/audio/realtime_backend/WASM_GUIDE.md
+++ b/src/audio/realtime_backend/WASM_GUIDE.md
@@ -1,0 +1,55 @@
+# WebAssembly Guide
+
+This document explains how to compile the Rust based realtime DSP backend into a WebAssembly component and use it for high speed Web Audio.
+
+## Prerequisites
+
+- Rust toolchain (stable or nightly)
+- [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/)
+- `wasm32-unknown-unknown` target installed via `rustup target add wasm32-unknown-unknown`
+- A modern JavaScript bundler or build tool (e.g. Vite, Webpack)
+
+## Building the WASM module
+
+1. Navigate to the realtime backend crate:
+
+   ```bash
+   cd src/audio/realtime_backend
+   ```
+
+2. Build with `wasm-pack`:
+
+   ```bash
+   wasm-pack build --target web --release
+   ```
+
+   This generates a `pkg/` directory containing `realtime_backend.js` and `realtime_backend_bg.wasm`.
+
+3. Copy the contents of `pkg/` into your web application's source directory or serve them directly.
+
+## Using in the Browser
+
+Import the generated module and initialize it before starting audio playback:
+
+```javascript
+import init, { start_stream, stop_stream } from './realtime_backend.js';
+
+async function initAudio(trackJson) {
+  await init(); // loads realtime_backend_bg.wasm
+  await start_stream(JSON.stringify(trackJson));
+}
+```
+
+The exported functions mirror the Python bindings. `start_stream` begins playback using the Web Audio API under the hood, while `stop_stream` halts it.
+
+### Performance Notes
+
+WebAssembly allows the DSP routines to run at near-native speed in the browser. For best results, ensure the audio worklet thread is not blocked by heavy JavaScript processing. The module currently outputs stereo samples at the browser's sample rate and writes them into a `ScriptProcessor` or `AudioWorklet` node.
+
+### Limitations
+
+- Only the implemented voices in `realtime_backend` are available.
+- Browser security policies may require user interaction before audio can start.
+
+Refer to `REALTIME_BACKEND_PLAN.md` for the remaining tasks and planned features.
+


### PR DESCRIPTION
## Summary
- document how to compile the realtime backend to WebAssembly
- link the new guide from README_Audio

## Testing
- `cargo check` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861ed2a0e40832da6c0dd723780b050