### PR TITLE
Add subliminal encode voice

### DIFF
--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -18,4 +18,5 @@ rand = "0.8"
 crossbeam = "0.8"
 parking_lot = "0.12"
 once_cell = "1.19"
+symphonia = { version = "0.5.4", features = ["default", "mp3"] }
 


### PR DESCRIPTION
## Summary
- implement new `SubliminalEncodeVoice` with audio file loading and modulation
- add audio decoding with `symphonia`
- map `subliminal_encode` to new voice

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68620a246ee4832db0a06356925e8645