### PR TITLE
Add realtime_backend usage docs

### DIFF
--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -19,3 +19,35 @@ Remaining tasks (see `REALTIME_BACKEND_PLAN.md` for full roadmap):
 - Crossfade and transition handling in `TrackScheduler`.
 - Unit tests comparing DSP routines with the Python version.
 - Integration with the rest of the application via a high-level Python wrapper.
+
+## Building the Python Extension
+
+Install [maturin](https://github.com/PyO3/maturin) and compile the library as a Python module:
+
+```bash
+pip install maturin
+cd src/audio/realtime_backend
+maturin develop --release
+```
+
+This produces a `realtime_backend` extension that can be imported from Python:
+
+```python
+import realtime_backend
+
+# `track_json` should be a JSON string exported by the GUI
+realtime_backend.start_stream(track_json)
+```
+
+Call `realtime_backend.stop_stream()` to halt playback.
+
+## WebAssembly Build
+
+The backend can also be compiled to WebAssembly for use in the browser.
+Install `wasm-pack` and build the crate:
+
+```bash
+wasm-pack build --target web --release
+```
+
+The generated `pkg/` folder contains `realtime_backend.js` and `realtime_backend_bg.wasm`.  See `WASM_GUIDE.md` for integration details.


### PR DESCRIPTION
## Summary
- document how to build the Rust realtime backend as a Python extension
- add WebAssembly build instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68620f21fc28832db1d4938eba6b9b33