### PR TITLE
Enable WASM build of realtime backend

### DIFF
--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -1,3 +1,4 @@
+
 [package]
 name = "realtime_backend"
 version = "0.1.0"
@@ -7,17 +8,25 @@ edition = "2021"
 name = "realtime_backend"
 crate-type = ["cdylib"]
 
+[features]
+default = ["python"]
+python = ["pyo3", "crossbeam"]
+web = ["wasm-bindgen", "js-sys"]
+
 [dependencies]
-pyo3 = { version = "0.21.0", features = ["extension-module"] }
-cpal = "0.15.3"
+pyo3 = { version = "0.21.0", optional = true, features = ["extension-module"] }
+wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rustfft = "6.1"
 biquad = "0.4"
 rand = "0.8"
-crossbeam = "0.8"
+crossbeam = { version = "0.8", optional = true }
 parking_lot = "0.12"
 once_cell = "1.19"
 symphonia = { version = "0.5.4", features = ["default", "mp3"] }
-
 getrandom = { version = "0.2", features = ["js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cpal = "0.15.3"

--- a/src/audio/realtime_backend/WASM_GUIDE.md
+++ b/src/audio/realtime_backend/WASM_GUIDE.md
@@ -17,10 +17,10 @@ This document explains how to compile the Rust based realtime DSP backend into a
    cd src/audio/realtime_backend
    ```
 
-2. Build with `wasm-pack`:
+2. Build with `wasm-pack` (using the `web` feature):
 
    ```bash
-   wasm-pack build --target web --release
+   wasm-pack build --target web --release --no-default-features --features web
    ```
 
    This generates a `pkg/` directory containing `realtime_backend.js` and `realtime_backend_bg.wasm`.


### PR DESCRIPTION
## Summary
- allow building realtime backend for Python or WebAssembly using features
- update build steps for WASM in documentation

## Testing
- `cargo check` *(fails: error about missing system library alsa before installing packages, after installation passes)*
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown`

------
https://chatgpt.com/codex/tasks/task_e_6862a73dd9a0832d91dae066a0d6c489