### PR TITLE
Add basic web UI for realtime backend

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -232,3 +232,22 @@ is provided). Step boundaries are shown as dashed lines so you can quickly
 identify when the track transitions from one step to the next. If a file path
 ending in `.html` is supplied, the timeline is saved as a standalone web page.
 
+
+## Web Interface
+
+A small browser-based demo is located in `src/audio/web_ui`. It uses the
+`realtime_backend` crate compiled to WebAssembly to play tracks directly in the
+browser.
+
+1. Build the backend with `wasm-pack`:
+   ```bash
+   cd src/audio/realtime_backend
+   wasm-pack build --target web --release --no-default-features --features web
+   ```
+2. Copy the resulting `pkg` directory into `src/audio/web_ui/`.
+3. Serve the `web_ui` folder with any HTTP server, e.g. `python -m http.server`,
+   and open the page in your browser.
+
+Paste a track JSON object into the text area and press **Start** to hear it
+render in real time.
+

--- a/src/audio/web_ui/README.md
+++ b/src/audio/web_ui/README.md
@@ -1,0 +1,28 @@
+# Web UI for the Realtime Backend
+
+This directory provides a minimal browser interface for the Rust audio engine
+when compiled to WebAssembly. It is meant for quick experimentation directly
+from a web page.
+
+## Building the WebAssembly Package
+
+1. Install [`wasm-pack`](https://rustwasm.github.io/wasm-pack/installer/).
+2. Build the backend with the `web` feature enabled:
+   ```bash
+   cd ../realtime_backend
+   wasm-pack build --target web --release --no-default-features --features web
+   ```
+3. Copy the generated `pkg` folder into this directory so `index.html` can load
+   `realtime_backend.js` and `realtime_backend_bg.wasm`.
+
+## Running the Demo
+
+Serve the `web_ui` directory with any static web server. One simple option is:
+
+```bash
+python -m http.server
+```
+
+Then open `http://localhost:8000` in your browser. Paste a track JSON object into
+the text box and click **Start** to begin playback. Press **Stop** to halt the
+engine.

--- a/src/audio/web_ui/app.js
+++ b/src/audio/web_ui/app.js
@@ -1,0 +1,51 @@
+import init, { start_stream, process_block, stop_stream } from './realtime_backend.js';
+
+let audioCtx = null;
+let scriptNode = null;
+let wasmLoaded = false;
+
+async function ensureWasmLoaded() {
+  if (!wasmLoaded) {
+    await init();
+    wasmLoaded = true;
+  }
+}
+
+function setupAudio() {
+  const bufferSize = 1024;
+  audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  scriptNode = audioCtx.createScriptProcessor(bufferSize, 0, 2);
+  scriptNode.onaudioprocess = (e) => {
+    const frames = e.outputBuffer.length;
+    const data = process_block(frames * 2);
+    const left = e.outputBuffer.getChannelData(0);
+    const right = e.outputBuffer.getChannelData(1);
+    for (let i = 0; i < frames; i++) {
+      left[i] = data[i * 2];
+      right[i] = data[i * 2 + 1];
+    }
+  };
+  scriptNode.connect(audioCtx.destination);
+}
+
+export async function start() {
+  await ensureWasmLoaded();
+  const trackJson = document.getElementById('track-json').value;
+  start_stream(trackJson);
+  setupAudio();
+}
+
+export function stop() {
+  stop_stream();
+  if (scriptNode) {
+    scriptNode.disconnect();
+    scriptNode = null;
+  }
+  if (audioCtx) {
+    audioCtx.close();
+    audioCtx = null;
+  }
+}
+
+document.getElementById('start').addEventListener('click', start);
+document.getElementById('stop').addEventListener('click', stop);

--- a/src/audio/web_ui/index.html
+++ b/src/audio/web_ui/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Realtime Backend Web Demo</title>
+</head>
+<body>
+  <h1>Realtime Backend Web Demo</h1>
+  <textarea id="track-json" rows="10" cols="80">{\n  \"sample_rate\": 44100,\n  \"crossfade\": 0.05,\n  \"steps\": []\n}</textarea><br>
+  <button id="start">Start</button>
+  <button id="stop">Stop</button>
+  <script type="module" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `web_ui` demo for realtime backend
- document building the WebAssembly package
- reference new web interface in the audio README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cargo test` *(fails: `alsa-sys` missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_6862ab165fbc832dabbe08c453e05b10