### PR TITLE
Integrate Vite-based frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 
 __pycache__/
 *.pyc
+node_modules/
+src/audio/web_ui/dist/
 

--- a/src/audio/web_ui/README.md
+++ b/src/audio/web_ui/README.md
@@ -12,17 +12,18 @@ from a web page.
    cd ../realtime_backend
    wasm-pack build --target web --release --no-default-features --features web
    ```
-3. Copy the generated `pkg` folder into this directory so `index.html` can load
-   `realtime_backend.js` and `realtime_backend_bg.wasm`.
+3. Copy the generated `pkg` folder into `public/` so Vite can serve
+    `realtime_backend.js` and `realtime_backend_bg.wasm`.
 
 ## Running the Demo
 
-Serve the `web_ui` directory with any static web server. One simple option is:
+Install the npm dependencies and start the development server:
 
 ```bash
-python -m http.server
+npm install
+npm run dev
 ```
 
-Then open `http://localhost:8000` in your browser. Paste a track JSON object into
+Vite will serve the application at the printed URL. Paste a track JSON object into
 the text box and click **Start** to begin playback. Press **Stop** to halt the
 engine.

--- a/src/audio/web_ui/index.html
+++ b/src/audio/web_ui/index.html
@@ -9,6 +9,6 @@
   <textarea id="track-json" rows="10" cols="80">{\n  \"sample_rate\": 44100,\n  \"crossfade\": 0.05,\n  \"steps\": []\n}</textarea><br>
   <button id="start">Start</button>
   <button id="stop">Stop</button>
-  <script type="module" src="app.js"></script>
+  <script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/src/audio/web_ui/package.json
+++ b/src/audio/web_ui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "realtime-web-ui",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0"
+  }
+}

--- a/src/audio/web_ui/src/main.js
+++ b/src/audio/web_ui/src/main.js
@@ -1,4 +1,4 @@
-import init, { start_stream, process_block, stop_stream } from './realtime_backend.js';
+import init, { start_stream, process_block, stop_stream } from '/pkg/realtime_backend.js';
 
 let audioCtx = null;
 let scriptNode = null;

--- a/src/audio/web_ui/vite.config.js
+++ b/src/audio/web_ui/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    open: true,
+  },
+  build: {
+    outDir: 'dist',
+  },
+});


### PR DESCRIPTION
## Summary
- convert audio web UI to a small Vite project
- rename `app.js` to `src/main.js`
- add package.json and Vite config
- update README with Vite instructions
- ignore node modules and build output

## Testing
- `npm --version`
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd426a64832d904a2e50ad202d71