### PR TITLE
Suppress unused warnings in realtime backend

### DIFF
--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
 #[cfg(feature = "python")]
 mod audio_io;
 mod dsp;


### PR DESCRIPTION
## Summary
- suppress `dead_code` and `unused_imports` warnings in realtime backend crate by adding crate-level attributes

## Testing
- `cargo check --no-default-features --features web --target wasm32-unknown-unknown`

------
https://chatgpt.com/codex/tasks/task_e_6862e6af5fe8832db666ca37fa423710