### PR TITLE
Require Node 20 for Vite web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,15 @@ See the [GUI overview](#gui-overview) below for more details on generating audio
     ```
 
     > *(Note: `pyaudio` installation might require system dependencies - see below).*
-4. **Install PlatformIO:** On your development PC (Windows), install PlatformIO IDE, typically via the VS Code extension. This handles the C++ toolchain (compiler, etc.).
-5. **Install External Dependencies:**
+4. **Install Node.js 20+:** The optional web interface in `src/audio/web_ui` is built with Vite, which requires Node.js version 20 or later. Install it from [nodejs.org](https://nodejs.org) if you plan to run the web UI.
+5. **Install PlatformIO:** On your development PC (Windows), install PlatformIO IDE, typically via the VS Code extension. This handles the C++ toolchain (compiler, etc.).
+6. **Install External Dependencies:**
     * **Audio Playback (`controller.py`):**
         * **PortAudio:** Required by `pyaudio`. Install system-wide (e.g., `sudo apt-get install portaudio19-dev` on Debian/Pi, or download installers/binaries for Windows/macOS if needed).
         * **libsndfile:** Required by `soundfile`. Install system-wide (e.g., `sudo apt-get install libsndfile1` on Debian/Pi, or download installers/binaries for Windows/macOS).
         * **ffmpeg / ffplay:** Required by `controller.py`'s `AudioPlayer` for MP3 conversion and FLAC playback. Download from ffmpeg.org and ensure `ffmpeg.exe` and `ffplay.exe` are in your system's PATH environment variable on the machine running `controller.py` (Windows and/or Pi).
-6. **Hardware Setup:** Connect the ESP32, build/connect your MOSFET driver circuits and LEDs according to the description in [Hardware Components](./README_Visual#hardware-components).
-7. **Initial Firmware Upload:** Use PlatformIO (e.g., in VS Code) on your development PC to compile and upload the initial ESP32 firmware project (`main.cpp`, `sequences.cpp`, etc.) to the ESP32-C3 board via USB.
+7. **Hardware Setup:** Connect the ESP32, build/connect your MOSFET driver circuits and LEDs according to the description in [Hardware Components](./README_Visual#hardware-components).
+8. **Initial Firmware Upload:** Use PlatformIO (e.g., in VS Code) on your development PC to compile and upload the initial ESP32 firmware project (`main.cpp`, `sequences.cpp`, etc.) to the ESP32-C3 board via USB.
 
 ---
 

--- a/src/audio/web_ui/README.md
+++ b/src/audio/web_ui/README.md
@@ -17,7 +17,7 @@ from a web page.
 
 ## Running the Demo
 
-Install the npm dependencies and start the development server:
+Install the npm dependencies and start the development server. **Vite 5 requires Node.js 20 or newer**, so ensure you have an up-to-date Node.js installation:
 
 ```bash
 npm install

--- a/src/audio/web_ui/package.json
+++ b/src/audio/web_ui/package.json
@@ -2,6 +2,9 @@
   "name": "realtime-web-ui",
   "private": true,
   "version": "0.0.0",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- document Node 20 requirement in main README and web UI docs
- enforce minimum Node version in web UI `package.json`

## Testing
- `npm run build --silent` *(fails: Rollup failed to resolve import `/pkg/realtime_backend.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6862e8662884832da67da31f8bd24e50