### PR TITLE
Enable runtime track updates

### DIFF
--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -52,12 +52,33 @@ fn stop_stream() -> PyResult<()> {
     Ok(())
 }
 
+#[cfg(feature = "python")]
+#[pyfunction]
+fn update_track(track_json_str: String) -> PyResult<()> {
+    let track_data: TrackData = serde_json::from_str(&track_json_str)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+    if let Some(engine) = &*ENGINE_STATE.lock() {
+        engine.lock().update_track(track_data);
+    }
+    Ok(())
+}
+
 #[cfg(feature = "web")]
 #[wasm_bindgen]
 pub fn start_stream(track_json_str: &str) {
     let track_data: TrackData = serde_json::from_str(track_json_str).unwrap();
     let scheduler = Arc::new(Mutex::new(TrackScheduler::new(track_data)));
     *ENGINE_STATE.lock() = Some(scheduler);
+}
+
+#[cfg(feature = "web")]
+#[wasm_bindgen]
+pub fn update_track(track_json_str: &str) {
+    if let Some(engine) = &*ENGINE_STATE.lock() {
+        if let Ok(track_data) = serde_json::from_str(track_json_str) {
+            engine.lock().update_track(track_data);
+        }
+    }
 }
 
 #[cfg(feature = "web")]
@@ -81,5 +102,6 @@ pub fn stop_stream() {
 fn realtime_backend(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(start_stream, m)?)?;
     m.add_function(wrap_pyfunction!(stop_stream, m)?)?;
+    m.add_function(wrap_pyfunction!(update_track, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- allow updating TrackScheduler with new track data
- expose `update_track` function for Python and Web targets
- reload clips and background noise when a track changes

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6862f6cfc7e0832d9e46ed4ce4bd8331