### PR TITLE
Remove forceMono from Binaural Beat voice

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -92,7 +92,6 @@ Creates the classic binaural beat illusion by playing two close frequencies.
 | `ampL` / `ampR` | 0.5 | Amplitude of each ear |
 | `baseFreq` | 200 | Center frequency of the beat |
 | `beatFreq` | 4 | Difference between left and right tones |
-| `forceMono` | False | If true, forces both ears to the same tone |
 | `startPhaseL` / `startPhaseR` | 0 | Initial phase of each tone |
 | `ampOscDepthL` / `ampOscDepthR` | 0 | Depth of amplitude modulation |
 | `ampOscFreqL` / `ampOscFreqR` | 0 | Frequency of amplitude modulation |

--- a/src/audio/ui/voice_editor_dialog.py
+++ b/src/audio/ui/voice_editor_dialog.py
@@ -1224,7 +1224,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
             "binaural_beat": { # This is an example, ensure it's correct
                 "standard": [
                     ('ampL', 0.5), ('ampR', 0.5), ('baseFreq', 200.0), ('beatFreq', 4.0),
-                    ('forceMono', False), ('startPhaseL', 0.0), ('startPhaseR', 0.0),
+                    ('startPhaseL', 0.0), ('startPhaseR', 0.0),
                     ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0),
                     ('ampOscDepthR', 0.0), ('ampOscFreqR', 0.0),
                     ('freqOscRangeL', 0.0), ('freqOscFreqL', 0.0),
@@ -1239,7 +1239,6 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startAmpR', 0.5), ('endAmpR', 0.5),
                     ('startBaseFreq', 200.0), ('endBaseFreq', 200.0),
                     ('startBeatFreq', 4.0), ('endBeatFreq', 4.0),
-                    ('startForceMono', 0.0), ('endForceMono', 0.0), # Should be bool if possible, or handled as 0/1
                     ('startStartPhaseL', 0.0), ('endStartPhaseL', 0.0),
                     ('startStartPhaseR', 0.0), ('endStartPhaseR', 0.0),
                     ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0),


### PR DESCRIPTION
## Summary
- drop unused `forceMono` parameter from binaural beat synth functions
- remove `forceMono` options from the voice editor
- update README accordingly

## Testing
- `python -m py_compile src/audio/synth_functions/binaural_beat.py`
- `python -m py_compile src/audio/ui/voice_editor_dialog.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68635adf6684832d9b8e5f59c138b2f0