### PR TITLE
Add file upload to audio web_ui

### DIFF
--- a/src/audio/web_ui/README.md
+++ b/src/audio/web_ui/README.md
@@ -24,6 +24,6 @@ npm install
 npm run dev
 ```
 
-Vite will serve the application at the printed URL. Paste a track JSON object into
-the text box and click **Start** to begin playback. Press **Stop** to halt the
-engine.
+Vite will serve the application at the printed URL. You can either paste a track
+JSON object into the text box or use the **Upload** field to load a `.json`
+file. Click **Start** to begin playback and **Stop** to halt the engine.

--- a/src/audio/web_ui/index.html
+++ b/src/audio/web_ui/index.html
@@ -6,6 +6,7 @@
 </head>
 <body>
   <h1>Realtime Backend Web Demo</h1>
+  <input type="file" id="json-upload" accept=".json"><br>
   <textarea id="track-json" rows="10" cols="80">{\n  \"sample_rate\": 44100,\n  \"crossfade\": 0.05,\n  \"steps\": []\n}</textarea><br>
   <button id="start">Start</button>
   <button id="stop">Stop</button>

--- a/src/audio/web_ui/src/main.js
+++ b/src/audio/web_ui/src/main.js
@@ -49,3 +49,13 @@ export function stop() {
 
 document.getElementById('start').addEventListener('click', start);
 document.getElementById('stop').addEventListener('click', stop);
+
+document.getElementById('json-upload').addEventListener('change', (event) => {
+  const file = event.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    document.getElementById('track-json').value = e.target.result;
+  };
+  reader.readAsText(file);
+});


### PR DESCRIPTION
## Summary
- allow the web UI to load JSON files instead of just pasting data
- document how to upload JSON in the web UI README

## Testing
- `npm install`
- `npm run build` *(fails: Rollup failed to resolve import)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68634b60711c832d8f43033e7933b556