### PR TITLE
Fix fallback audio stream config

### DIFF
--- a/src/audio/realtime_backend/src/audio_io.rs
+++ b/src/audio/realtime_backend/src/audio_io.rs
@@ -11,26 +11,58 @@ pub fn run_audio_stream(scheduler: Arc<Mutex<TrackScheduler>>, stop_rx: Receiver
     let device = host
         .default_output_device()
         .expect("no output device available");
-    let supported_config = device.default_output_config().expect("no default config");
+    let supported_config = device
+        .default_output_config()
+        .expect("no default config");
     let sample_format = supported_config.sample_format();
-    let mut config: StreamConfig = supported_config.into();
+    let mut config: StreamConfig = supported_config.clone().into();
 
     // Use the scheduler's sample rate if it differs from the device default.
     let desired_rate = scheduler.lock().sample_rate as u32;
     if desired_rate != config.sample_rate.0 {
-        config.sample_rate.0 = desired_rate;
+        if let Ok(mut ranges) = device.supported_output_configs() {
+            if let Some(range) = ranges.find(|r| {
+                r.channels() == config.channels
+                    && r.sample_format() == sample_format
+                    && r.min_sample_rate().0 <= desired_rate
+                    && desired_rate <= r.max_sample_rate().0
+            }) {
+                config = range
+                    .with_sample_rate(cpal::SampleRate(desired_rate))
+                    .config();
+            } else {
+                eprintln!(
+                    "Sample rate {} not supported, using {}",
+                    desired_rate, config.sample_rate.0
+                );
+            }
+        } else {
+            eprintln!("Could not query supported output configs; using default");
+        }
     }
 
+    let scheduler_cb = scheduler.clone();
     let audio_callback = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        let mut scheduler = scheduler.lock();
-        scheduler.process_block(data);
+        let mut sched = scheduler_cb.lock();
+        sched.process_block(data);
     };
-    let err_fn = |err| eprintln!("stream error: {err}");
 
     let stream = match sample_format {
-        SampleFormat::F32 => device
-            .build_output_stream(&config, audio_callback, err_fn, None)
-            .unwrap(),
+        SampleFormat::F32 => match device.build_output_stream(&config, audio_callback, |err| eprintln!("stream error: {err}"), None) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Failed to build stream with desired config: {e}. Falling back to default config.");
+                let fallback: StreamConfig = supported_config.into();
+                let scheduler_fb = scheduler.clone();
+                let fb_callback = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
+                    let mut sched = scheduler_fb.lock();
+                    sched.process_block(data);
+                };
+                device
+                    .build_output_stream(&fallback, fb_callback, |err| eprintln!("stream error: {err}"), None)
+                    .expect("failed to build output stream")
+            }
+        },
         _ => panic!("Unsupported sample format"),
     };
     stream.play().unwrap();


### PR DESCRIPTION
## Summary
- avoid panicking when the audio device does not support the requested sample rate
- fall back to the default configuration when `StreamConfigNotSupported` occurs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `cargo check --features python`


------
https://chatgpt.com/codex/tasks/task_e_68642b862e2c832db674e3a2f0c17e26