### PR TITLE
Fix timing aliases and add normalization

### DIFF
--- a/src/audio/realtime_backend/src/models.rs
+++ b/src/audio/realtime_backend/src/models.rs
@@ -13,10 +13,13 @@ pub struct VolumeEnvelope {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct VoiceData {
+    #[serde(alias = "synthFunctionName", alias = "synth_function")]
     pub synth_function_name: String,
+    #[serde(alias = "parameters", default)]
     pub params: HashMap<String, serde_json::Value>,
+    #[serde(alias = "volumeEnvelope")]
     pub volume_envelope: Option<VolumeEnvelope>,
-    #[serde(default)]
+    #[serde(default, alias = "isTransition")]
     pub is_transition: bool,
     #[serde(default)]
     pub description: String,
@@ -24,6 +27,7 @@ pub struct VoiceData {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct StepData {
+    #[serde(alias = "Duration", alias = "durationSeconds", alias = "stepDuration")]
     pub duration: f64,
     #[serde(default)]
     pub description: String,
@@ -32,17 +36,19 @@ pub struct StepData {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct GlobalSettings {
+    #[serde(alias = "sampleRate")]
     pub sample_rate: u32,
-    #[serde(default = "default_crossfade_duration")]
+    #[serde(default = "default_crossfade_duration", alias = "crossfadeDuration")]
     pub crossfade_duration: f64,
-    #[serde(default = "default_crossfade_curve")]
+    #[serde(default = "default_crossfade_curve", alias = "crossfadeCurve")]
     pub crossfade_curve: String,
-    #[serde(default)]
+    #[serde(default, alias = "outputFilename")]
     pub output_filename: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct TrackData {
+    #[serde(alias = "globalSettings")]
     pub global_settings: GlobalSettings,
     pub steps: Vec<StepData>,
     #[serde(default)]

--- a/src/audio/realtime_backend/src/scheduler.rs
+++ b/src/audio/realtime_backend/src/scheduler.rs
@@ -464,7 +464,7 @@ impl TrackScheduler {
             clip.position = pos;
         }
 
-        // Normalize the mixed buffer to prevent clipping
+        // Normalize the mixed buffer so the peak does not exceed 0.3
         let mut max_abs = 0.0f32;
         for &sample in buffer.iter() {
             let val = sample.abs();
@@ -472,8 +472,8 @@ impl TrackScheduler {
                 max_abs = val;
             }
         }
-        if max_abs > 1.0 {
-            let norm = 1.0 / max_abs;
+        if max_abs > 1e-9 {
+            let norm = 0.3 / max_abs;
             for v in buffer.iter_mut() {
                 *v *= norm;
             }


### PR DESCRIPTION
## Summary
- support camelCase timing keys in realtime backend
- normalize mixed audio to a maximum of 0.3

## Testing
- `cargo check` *(fails: `alsa-sys` build error)*

------
https://chatgpt.com/codex/tasks/task_e_68643ab9a848832dbbf2a16d7fc04e58