### PR TITLE
Implement new track JSON structure

### DIFF
--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -13,6 +13,19 @@ data = load_track_from_json("track.json")
 generate_audio(data, "output.wav")
 ```
 
+Track definition files now use a nested structure:
+
+```json
+{
+  "global": {"sample_rate": 44100, "crossfade_duration": 1.0},
+  "progression": [
+    {"start": 0, "duration": 8.0, "voices": []}
+  ],
+  "background_noise": {},
+  "overlay_clips": []
+}
+```
+
 Noise generator settings can be stored separately using `.noise` files:
 
 ```
@@ -211,7 +224,8 @@ If omitted, `linear` is used.
 
 Additional audio material can be layered on top of the generated voices using
 the **Overlay Clips** panel in the editor.  Each clip entry stores the file
-path, a start time, amplitude, pan position and optional fade times.  The
+path, a start time, amplitude, pan position and optional fade times.  In the
+JSON definition these live under the ``overlay_clips`` list. The
 duration and finish time columns are populated automatically after a file is
 selected.  You can audition a single clip without exporting the entire track by
 highlighting it and pressing **Start Clip**; the button changes to **Stop Clip**
@@ -222,8 +236,8 @@ while the preview is playing.
 The helper function `audio.visualize_track_timeline()` now renders a more
 "DAW-like" timeline view using **Plotly**. Each track lane is drawn similar to
 clips in a digital audio workstation, making it easier to see how binaural
-voices, vocals, sound effects and background noise overlap. Pass the same JSON
-structure used for audio generation to this function and it will display (or
+voices, vocals, sound effects and background noise overlap. Pass the track
+definition (as shown above) to this function and it will display (or
 save) the interactive timeline. You can zoom, pan and hover to inspect specific
 segments. Individual voices and overlay clips are color-coded within their
 categories and labeled using their descriptions (or filenames if no description

--- a/src/audio/web_ui/index.html
+++ b/src/audio/web_ui/index.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Realtime Backend Web Demo</h1>
   <input type="file" id="json-upload" accept=".json"><br>
-  <textarea id="track-json" rows="10" cols="80">{\n  \"sample_rate\": 44100,\n  \"crossfade\": 0.05,\n  \"steps\": []\n}</textarea><br>
+  <textarea id="track-json" rows="10" cols="80">{\n  \"global\": {\"sample_rate\": 44100},\n  \"progression\": [],\n  \"background_noise\": {},\n  \"overlay_clips\": []\n}</textarea><br>
   <button id="start">Start</button>
   <button id="stop">Stop</button>
   <script type="module" src="/src/main.js"></script>

--- a/src/audio/web_ui/src/main.js
+++ b/src/audio/web_ui/src/main.js
@@ -36,7 +36,9 @@ export async function start() {
   let sampleRate = 44100;
   try {
     const trackObj = JSON.parse(trackJson);
-    if (trackObj.global_settings && trackObj.global_settings.sample_rate) {
+    if (trackObj.global && trackObj.global.sample_rate) {
+      sampleRate = trackObj.global.sample_rate;
+    } else if (trackObj.global_settings && trackObj.global_settings.sample_rate) {
       sampleRate = trackObj.global_settings.sample_rate;
     } else if (trackObj.sample_rate) {
       sampleRate = trackObj.sample_rate;


### PR DESCRIPTION
## Summary
- redesign track JSON format for audio portion
- update parser in `sound_creator` to load both old and new layouts
- save tracks using the new v2 keys
- support explicit step start times in track assembler
- document JSON changes and update web demo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68644316db2c832da91558df781a00e0