### PR TITLE
Support new track JSON keys

### DIFF
--- a/src/audio/realtime_backend/src/models.rs
+++ b/src/audio/realtime_backend/src/models.rs
@@ -48,12 +48,13 @@ pub struct GlobalSettings {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct TrackData {
-    #[serde(alias = "globalSettings")]
+    #[serde(alias = "globalSettings", alias = "global")]
     pub global_settings: GlobalSettings,
+    #[serde(alias = "progression")]
     pub steps: Vec<StepData>,
-    #[serde(default)]
+    #[serde(default, alias = "overlay_clips")]
     pub clips: Vec<ClipData>,
-    #[serde(default)]
+    #[serde(default, alias = "noise")]
     pub background_noise: Option<BackgroundNoiseData>,
 }
 


### PR DESCRIPTION
## Summary
- allow realtime backend to parse new global/progression keys

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644cfdf440832d819a07a05955d240