### PR TITLE
Implement realtime backend fixes

### DIFF
--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -23,6 +23,7 @@ rustfft = "6.1"
 biquad = "0.4"
 rand = "0.8"
 crossbeam = { version = "0.8", optional = true }
+ringbuf = "0.4"
 parking_lot = "0.12"
 once_cell = "1.19"
 symphonia = { version = "0.5.4", features = ["default", "mp3"] }

--- a/src/audio/realtime_backend/src/command.rs
+++ b/src/audio/realtime_backend/src/command.rs
@@ -1,0 +1,6 @@
+use crate::models::TrackData;
+
+#[derive(Debug)]
+pub enum Command {
+    UpdateTrack(TrackData),
+}

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -6,13 +6,20 @@ mod audio_io;
 mod dsp;
 mod models;
 mod scheduler;
+mod command;
 mod voices;
 
 use models::TrackData;
 use scheduler::TrackScheduler;
 use parking_lot::Mutex;
 use once_cell::sync::Lazy;
-use std::sync::Arc;
+use ringbuf::{HeapRb, HeapProd, HeapCons};
+use ringbuf::traits::{Producer, Consumer, Split};
+#[cfg(feature = "python")]
+use cpal::traits::HostTrait;
+#[cfg(feature = "python")]
+use cpal::traits::DeviceTrait;
+use command::Command;
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -23,23 +30,35 @@ use crossbeam::channel::{unbounded, Sender};
 #[cfg(feature = "web")]
 use wasm_bindgen::prelude::*;
 
-static ENGINE_STATE: Lazy<Mutex<Option<Arc<Mutex<TrackScheduler>>>>> = Lazy::new(|| Mutex::new(None));
+static ENGINE_STATE: Lazy<Mutex<Option<HeapProd<Command>>>> = Lazy::new(|| Mutex::new(None));
 #[cfg(feature = "python")]
 static STOP_SENDER: Lazy<Mutex<Option<Sender<()>>>> = Lazy::new(|| Mutex::new(None));
+#[cfg(feature = "web")]
+thread_local! {
+    static WASM_SCHED: std::cell::RefCell<Option<(TrackScheduler, HeapCons<Command>)>> = std::cell::RefCell::new(None);
+}
 
 #[cfg(feature = "python")]
 #[pyfunction]
 fn start_stream(track_json_str: String) -> PyResult<()> {
     let track_data: TrackData = serde_json::from_str(&track_json_str)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
-    let scheduler = Arc::new(Mutex::new(TrackScheduler::new(track_data)));
-    *ENGINE_STATE.lock() = Some(scheduler.clone());
+
+    let host = cpal::default_host();
+    let device = host.default_output_device().ok_or_else(|| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("no output device"))?;
+    let cfg = device.default_output_config().map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let stream_rate = cfg.sample_rate().0;
+
+    let scheduler = TrackScheduler::new(track_data, stream_rate);
+    let rb = HeapRb::<Command>::new(1024);
+    let (prod, cons) = rb.split();
+    *ENGINE_STATE.lock() = Some(prod);
 
     let (tx, rx) = unbounded();
     *STOP_SENDER.lock() = Some(tx);
 
     std::thread::spawn(move || {
-        audio_io::run_audio_stream(scheduler, rx);
+        audio_io::run_audio_stream(scheduler, cons, rx);
     });
     Ok(())
 }
@@ -59,26 +78,30 @@ fn stop_stream() -> PyResult<()> {
 fn update_track(track_json_str: String) -> PyResult<()> {
     let track_data: TrackData = serde_json::from_str(&track_json_str)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
-    if let Some(engine) = &*ENGINE_STATE.lock() {
-        engine.lock().update_track(track_data);
+    if let Some(prod) = &mut *ENGINE_STATE.lock() {
+        let _ = prod.try_push(Command::UpdateTrack(track_data));
     }
     Ok(())
 }
 
 #[cfg(feature = "web")]
 #[wasm_bindgen]
-pub fn start_stream(track_json_str: &str) {
+pub fn start_stream(track_json_str: &str, sample_rate: u32) {
     let track_data: TrackData = serde_json::from_str(track_json_str).unwrap();
-    let scheduler = Arc::new(Mutex::new(TrackScheduler::new(track_data)));
-    *ENGINE_STATE.lock() = Some(scheduler);
+    let scheduler = TrackScheduler::new(track_data, sample_rate);
+    let rb = HeapRb::<Command>::new(1024);
+    let (prod, cons) = rb.split();
+    *ENGINE_STATE.lock() = Some(prod);
+    // In wasm mode we don't spawn a thread; scheduler is stored globally for pull processing
+    WASM_SCHED.with(|s| *s.borrow_mut() = Some((scheduler, cons)));
 }
 
 #[cfg(feature = "web")]
 #[wasm_bindgen]
 pub fn update_track(track_json_str: &str) {
-    if let Some(engine) = &*ENGINE_STATE.lock() {
+    if let Some(prod) = &mut *ENGINE_STATE.lock() {
         if let Ok(track_data) = serde_json::from_str(track_json_str) {
-            engine.lock().update_track(track_data);
+            let _ = prod.try_push(Command::UpdateTrack(track_data));
         }
     }
 }
@@ -87,9 +110,14 @@ pub fn update_track(track_json_str: &str) {
 #[wasm_bindgen]
 pub fn process_block(frame_count: usize) -> js_sys::Float32Array {
     let mut buf = vec![0.0f32; frame_count];
-    if let Some(engine) = &*ENGINE_STATE.lock() {
-        engine.lock().process_block(&mut buf);
-    }
+    WASM_SCHED.with(|s| {
+        if let Some((sched, cons)) = &mut *s.borrow_mut() {
+            while let Some(cmd) = cons.try_pop() {
+                sched.handle_command(cmd);
+            }
+            sched.process_block(&mut buf);
+        }
+    });
     js_sys::Float32Array::from(buf.as_slice())
 }
 
@@ -97,6 +125,7 @@ pub fn process_block(frame_count: usize) -> js_sys::Float32Array {
 #[wasm_bindgen]
 pub fn stop_stream() {
     *ENGINE_STATE.lock() = None;
+    WASM_SCHED.with(|s| *s.borrow_mut() = None);
 }
 
 #[cfg(feature = "python")]


### PR DESCRIPTION
## Summary
- update scheduler to use device sample rate and preallocate scratch buffer
- add non-blocking command ring buffer
- integrate soft clipping limiter
- use 64-bit frame counter
- update Python and WASM bindings

## Testing
- `cargo check --manifest-path src/audio/realtime_backend/Cargo.toml`
- `cargo test --manifest-path src/audio/realtime_backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68659498af28832da5b821ebc3a73bf7