### PR TITLE
Add sample WAV export to realtime backend

### DIFF
--- a/src/audio/realtime_backend.py
+++ b/src/audio/realtime_backend.py
@@ -41,4 +41,30 @@ def stop() -> None:
     _backend.stop_stream()
 
 
-__all__ = ["play_track", "play_track_file", "stop"]
+def write_sample_wav(track_definition: Dict[str, Any] | str, output_path: str) -> None:
+    """Generate a 60s WAV sample for ``track_definition``.
+
+    Parameters
+    ----------
+    track_definition:
+        Track data as ``dict`` or JSON string.
+    output_path:
+        Destination filename for the sample.
+    """
+    if isinstance(track_definition, str):
+        try:
+            json.loads(track_definition)
+            track_json = track_definition
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid JSON track definition") from exc
+    else:
+        track_json = json.dumps(track_definition)
+    _backend.render_sample_wav(track_json, output_path)
+
+
+__all__ = [
+    "play_track",
+    "play_track_file",
+    "stop",
+    "write_sample_wav",
+]

--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -28,6 +28,7 @@ parking_lot = "0.12"
 once_cell = "1.19"
 symphonia = { version = "0.5.4", features = ["default", "mp3"] }
 getrandom = { version = "0.2", features = ["js"] }
+hound = "3.5.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cpal = "0.15.3"

--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -37,6 +37,9 @@ import realtime_backend
 
 # `track_json` should be a JSON string exported by the GUI
 realtime_backend.start_stream(track_json)
+
+# Render a 60 second sample to a wav file
+realtime_backend.render_sample_wav(track_json, "sample.wav")
 ```
 
 Call `realtime_backend.stop_stream()` to halt playback.

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -27,6 +27,8 @@ use pyo3::prelude::*;
 use pyo3::prelude::Bound;
 #[cfg(feature = "python")]
 use crossbeam::channel::{unbounded, Sender};
+#[cfg(feature = "python")]
+use hound;
 #[cfg(feature = "web")]
 use wasm_bindgen::prelude::*;
 
@@ -84,6 +86,49 @@ fn update_track(track_json_str: String) -> PyResult<()> {
     Ok(())
 }
 
+#[cfg(feature = "python")]
+#[pyfunction]
+fn render_sample_wav(track_json_str: String, out_path: String) -> PyResult<()> {
+    use hound::{WavSpec, WavWriter, SampleFormat};
+    let track_data: TrackData = serde_json::from_str(&track_json_str)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+
+    let sample_rate = track_data.global_settings.sample_rate;
+    let mut scheduler = TrackScheduler::new(track_data.clone(), sample_rate);
+    let track_frames: usize = track_data
+        .steps
+        .iter()
+        .map(|s| (s.duration * sample_rate as f64) as usize)
+        .sum();
+    let target_frames = (sample_rate as usize * 60).min(track_frames);
+
+    let spec = WavSpec {
+        channels: 2,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+
+    let mut writer = WavWriter::create(&out_path, spec)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+
+    let mut remaining = target_frames;
+    let mut buffer = vec![0.0f32; 512 * 2];
+    while remaining > 0 {
+        let frames = 512.min(remaining);
+        buffer.resize(frames * 2, 0.0);
+        scheduler.process_block(&mut buffer);
+        for sample in &buffer[..frames * 2] {
+            let s = (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+            writer.write_sample(s).map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+        }
+        remaining -= frames;
+    }
+
+    writer.finalize().map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+    Ok(())
+}
+
 #[cfg(feature = "web")]
 #[wasm_bindgen]
 pub fn start_stream(track_json_str: &str, sample_rate: u32) {
@@ -134,5 +179,6 @@ fn realtime_backend(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(start_stream, m)?)?;
     m.add_function(wrap_pyfunction!(stop_stream, m)?)?;
     m.add_function(wrap_pyfunction!(update_track, m)?)?;
+    m.add_function(wrap_pyfunction!(render_sample_wav, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `render_sample_wav` function to Rust backend and expose via PyO3
- extend Python wrapper with `write_sample_wav`
- document new API in backend README
- add `hound` dependency for WAV output

## Testing
- `cargo build --quiet`
- `python -m py_compile src/audio/realtime_backend.py`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68659c4b5dbc832da03747d0e54f5fcf