### PR TITLE
Add CLI support to realtime backend

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -77,3 +77,14 @@ steps can still be heard in full.
 
 ### WebAssembly DSP Backend
 For browser-based projects you can compile the Rust realtime backend to WebAssembly. See [src/audio/realtime_backend/WASM_GUIDE.md](src/audio/realtime_backend/WASM_GUIDE.md) for build and usage steps.
+
+### CLI Playback
+In addition to the Python bindings, the realtime backend provides a small command
+line interface. After building the crate with Cargo you can directly play a track
+JSON file:
+
+```bash
+cargo run -p realtime_backend --bin play_json -- path/to/track.json
+```
+
+Use `Ctrl+C` to stop playback.

--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [lib]
 name = "realtime_backend"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["python"]
@@ -28,6 +28,8 @@ parking_lot = "0.12"
 once_cell = "1.19"
 symphonia = { version = "0.5.4", features = ["default", "mp3"] }
 getrandom = { version = "0.2", features = ["js"] }
+clap = { version = "4", features = ["derive"] }
+ctrlc = "3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cpal = "0.15.3"

--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -51,3 +51,15 @@ wasm-pack build --target web --release
 ```
 
 The generated `pkg/` folder contains `realtime_backend.js` and `realtime_backend_bg.wasm`.  See `WASM_GUIDE.md` for integration details.
+
+## Command Line Usage
+
+A small CLI binary is included for quickly auditioning track definitions without
+Python. Build the project normally and run `play_json` with a path to a JSON
+file exported from the GUI:
+
+```bash
+cargo run --bin play_json -- path/to/track.json
+```
+
+Press `Ctrl+C` to stop playback.

--- a/src/audio/realtime_backend/src/bin/play_json.rs
+++ b/src/audio/realtime_backend/src/bin/play_json.rs
@@ -1,0 +1,47 @@
+use clap::Parser;
+use realtime_backend::models::TrackData;
+use realtime_backend::scheduler::TrackScheduler;
+use realtime_backend::command::Command;
+use realtime_backend::audio_io;
+use ringbuf::HeapRb;
+use ringbuf::traits::Split;
+use crossbeam::channel::unbounded;
+use cpal::traits::{DeviceTrait, HostTrait};
+
+/// Simple CLI to play a track JSON file using the realtime backend
+#[derive(Parser)]
+struct Args {
+    /// Path to the track JSON file
+    track_file: String,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let json_str = std::fs::read_to_string(&args.track_file)?;
+    let track_data: TrackData = serde_json::from_str(&json_str)?;
+
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or("no output device")?;
+    let cfg = device.default_output_config()?;
+    let stream_rate = cfg.sample_rate().0;
+
+    let scheduler = TrackScheduler::new(track_data, stream_rate);
+    let rb = HeapRb::<Command>::new(1024);
+    let (_prod, cons) = rb.split();
+    let (tx, rx) = unbounded();
+
+    std::thread::spawn(move || {
+        audio_io::run_audio_stream(scheduler, cons, rx);
+    });
+
+    println!("Playing {}... press Ctrl+C to stop", args.track_file);
+    ctrlc::set_handler(move || {
+        let _ = tx.send(());
+    })?;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -2,12 +2,12 @@
 #![allow(unused_imports)]
 
 #[cfg(feature = "python")]
-mod audio_io;
-mod dsp;
-mod models;
-mod scheduler;
-mod command;
-mod voices;
+pub mod audio_io;
+pub mod dsp;
+pub mod models;
+pub mod scheduler;
+pub mod command;
+pub mod voices;
 
 use models::TrackData;
 use scheduler::TrackScheduler;


### PR DESCRIPTION
## Summary
- add a `play_json` binary to run track JSON files directly
- expose library modules so the binary can access them
- enable building both rlib and cdylib
- add `clap` and `ctrlc` dependencies
- document command line usage

## Testing
- `cargo check --manifest-path src/audio/realtime_backend/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68659dfaf824832d859f5ee53903c985