### PR TITLE
Add full track WAV export to realtime backend

### DIFF
--- a/src/audio/realtime_backend.py
+++ b/src/audio/realtime_backend.py
@@ -62,9 +62,31 @@ def write_sample_wav(track_definition: Dict[str, Any] | str, output_path: str) -
     _backend.render_sample_wav(track_json, output_path)
 
 
+def write_wav(track_definition: Dict[str, Any] | str, output_path: str) -> None:
+    """Render the entire track to a WAV file.
+
+    Parameters
+    ----------
+    track_definition:
+        Track data as ``dict`` or JSON string.
+    output_path:
+        Destination filename for the output.
+    """
+    if isinstance(track_definition, str):
+        try:
+            json.loads(track_definition)
+            track_json = track_definition
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid JSON track definition") from exc
+    else:
+        track_json = json.dumps(track_definition)
+    _backend.render_full_wav(track_json, output_path)
+
+
 __all__ = [
     "play_track",
     "play_track_file",
     "stop",
     "write_sample_wav",
+    "write_wav",
 ]

--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -40,6 +40,9 @@ realtime_backend.start_stream(track_json)
 
 # Render a 60 second sample to a wav file
 realtime_backend.render_sample_wav(track_json, "sample.wav")
+
+# Render the entire track to a wav file
+realtime_backend.render_full_wav(track_json, "full_output.wav")
 ```
 
 Call `realtime_backend.stop_stream()` to halt playback.


### PR DESCRIPTION
## Summary
- add `render_full_wav` in the realtime backend Rust crate to save the entire track
- expose the new function via PyO3 and wrapper `write_wav`
- document full export in realtime backend README

## Testing
- `cargo check --quiet` in `src/audio/realtime_backend`
- `python -m py_compile src/audio/realtime_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_6865a0558cf4832d8ba05e8a7aa755ba