### PR TITLE
Add CLI for realtime backend

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -88,3 +88,13 @@ cargo run -p realtime_backend --bin play_json -- path/to/track.json
 ```
 
 Use `Ctrl+C` to stop playback.
+
+You can also use a small Python CLI for quick testing. After building the
+`realtime_backend` extension, run:
+
+```bash
+./realtime backend --path path/to/track.json --generate
+```
+
+Omit `--generate` to stream the track in real time instead of rendering
+it to a WAV file.

--- a/realtime
+++ b/realtime
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from src.audio.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/src/audio/cli.py
+++ b/src/audio/cli.py
@@ -1,0 +1,37 @@
+import argparse
+from pathlib import Path
+
+from . import realtime_backend
+
+
+def _backend(args: argparse.Namespace) -> None:
+    """Handle the `backend` subcommand."""
+    track_path = Path(args.path)
+    if not track_path.is_file():
+        raise SystemExit(f"Track file not found: {track_path}")
+
+    if args.generate:
+        output_path = track_path.with_suffix('.wav')
+        with track_path.open('r', encoding='utf-8') as f:
+            track_json = f.read()
+        realtime_backend.write_wav(track_json, str(output_path))
+        print(f"WAV written to {output_path}")
+    else:
+        realtime_backend.play_track_file(str(track_path))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog='realtime', description='Realtime backend utilities')
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    backend_parser = subparsers.add_parser('backend', help='Play or render a track JSON file')
+    backend_parser.add_argument('--path', required=True, help='Path to track JSON file')
+    backend_parser.add_argument('--generate', action='store_true', help='Render full WAV instead of streaming')
+    backend_parser.set_defaults(func=_backend)
+
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add a `realtime` script for launching backend commands
- implement `src/audio/cli.py` with `backend` subcommand
- document the new CLI usage in `README_Audio.md`

## Testing
- `python -m py_compile src/audio/cli.py realtime src/audio/realtime_backend.py`
- `./realtime backend --path minimal_track.json --generate` *(fails: ModuleNotFoundError: No module named 'realtime_backend')*

------
https://chatgpt.com/codex/tasks/task_e_6865a1e4e8d8832da29c8ea528c91545