### PR TITLE
Add CLI for realtime backend

### DIFF
--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -60,12 +60,15 @@ The generated `pkg/` folder contains `realtime_backend.js` and `realtime_backend
 
 ## Command Line Usage
 
-A small CLI binary is included for quickly auditioning track definitions without
-Python. Build the project normally and run `play_json` with a path to a JSON
-file exported from the GUI:
+A command line interface is provided for quickly auditioning or rendering tracks
+without Python. Build the project normally and run the `realtime_backend`
+binary. Pass the path to a track JSON file and optionally enable full
+rendering:
 
 ```bash
-cargo run --bin play_json -- path/to/track.json
+cargo run --bin realtime_backend -- --path path/to/track.json --generate false
 ```
 
-Press `Ctrl+C` to stop playback.
+If `--generate true` is supplied, the entire track is written to the
+`outputFilename` specified in the JSON. Otherwise it streams the audio directly
+to the default output device. Press `Ctrl+C` to stop streaming.

--- a/src/audio/realtime_backend/src/bin/realtime_backend.rs
+++ b/src/audio/realtime_backend/src/bin/realtime_backend.rs
@@ -1,0 +1,101 @@
+use clap::Parser;
+use realtime_backend::models::TrackData;
+use realtime_backend::scheduler::TrackScheduler;
+use realtime_backend::command::Command;
+use realtime_backend::audio_io;
+use ringbuf::HeapRb;
+use ringbuf::traits::Split;
+use crossbeam::channel::unbounded;
+use cpal::traits::{DeviceTrait, HostTrait};
+
+/// CLI for streaming or rendering a track using the realtime backend
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to the track JSON file
+    #[arg(long)]
+    path: String,
+    /// Generate the full track to the output file instead of streaming
+    #[arg(long, default_value_t = false)]
+    generate: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let json_str = std::fs::read_to_string(&args.path)?;
+    let track_data: TrackData = serde_json::from_str(&json_str)?;
+
+    if args.generate {
+        let out_path = track_data
+            .global_settings
+            .output_filename
+            .clone()
+            .ok_or("outputFilename missing in global settings")?;
+        render_full_wav(track_data, &out_path)?;
+        println!("Generated full track at {}", out_path);
+        return Ok(());
+    }
+
+    let host = cpal::default_host();
+    let device = host
+        .default_output_device()
+        .ok_or("no output device")?;
+    let cfg = device.default_output_config()?;
+    let stream_rate = cfg.sample_rate().0;
+
+    let scheduler = TrackScheduler::new(track_data, stream_rate);
+    let rb = HeapRb::<Command>::new(1024);
+    let (_prod, cons) = rb.split();
+    let (tx, rx) = unbounded();
+
+    std::thread::spawn(move || {
+        audio_io::run_audio_stream(scheduler, cons, rx);
+    });
+
+    println!("Streaming {}... press Ctrl+C to stop", args.path);
+    ctrlc::set_handler(move || {
+        let _ = tx.send(());
+    })?;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+}
+
+fn render_full_wav(
+    track_data: TrackData,
+    out_path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use hound::{WavSpec, WavWriter, SampleFormat};
+    let sample_rate = track_data.global_settings.sample_rate;
+    let mut scheduler = TrackScheduler::new(track_data.clone(), sample_rate);
+    let target_frames: usize = track_data
+        .steps
+        .iter()
+        .map(|s| (s.duration * sample_rate as f64) as usize)
+        .sum();
+
+    let spec = WavSpec {
+        channels: 2,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+
+    let mut writer = WavWriter::create(out_path, spec)?;
+    let mut remaining = target_frames;
+    let mut buffer = vec![0.0f32; 512 * 2];
+    while remaining > 0 {
+        let frames = 512.min(remaining);
+        buffer.resize(frames * 2, 0.0);
+        scheduler.process_block(&mut buffer);
+        for sample in &buffer[..frames * 2] {
+            let s = (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16;
+            writer.write_sample(s)?;
+        }
+        remaining -= frames;
+    }
+
+    writer.finalize()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement a new Rust CLI binary `realtime_backend` for streaming or rendering tracks
- document new command line usage in the realtime backend README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6865a3a89adc832da827b1f715d0897f