### PR TITLE
Fix wasm build by gating ctrlc dependency

### DIFF
--- a/src/audio/realtime_backend/Cargo.toml
+++ b/src/audio/realtime_backend/Cargo.toml
@@ -30,7 +30,6 @@ once_cell = "1.19"
 symphonia = { version = "0.5.4", features = ["default", "mp3"] }
 getrandom = { version = "0.2", features = ["js"] }
 clap = { version = "4", features = ["derive"] }
-ctrlc = "3"
 hound = "3.5.1"
 wgpu = { version = "0.19", optional = true }
 pollster = { version = "0.3", optional = true }
@@ -38,3 +37,4 @@ pollster = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cpal = "0.15.3"
+ctrlc = "3"


### PR DESCRIPTION
## Summary
- place `ctrlc` dependency under `cfg(not(target_arch = "wasm32"))`

## Testing
- `wasm-pack build --target web --release --no-default-features --features web` *(fails to download binaryen)*

------
https://chatgpt.com/codex/tasks/task_e_6865d42cf5e8832db180e81d878112fb