### PR TITLE
Add render time print

### DIFF
--- a/src/audio/realtime_backend/src/bin/realtime_backend.rs
+++ b/src/audio/realtime_backend/src/bin/realtime_backend.rs
@@ -89,6 +89,7 @@ fn render_full_wav(
     };
 
     let mut writer = WavWriter::create(out_path, spec)?;
+    let start_time = std::time::Instant::now();
     let mut remaining = target_frames;
     let mut buffer = vec![0.0f32; 512 * 2];
     while remaining > 0 {
@@ -103,5 +104,7 @@ fn render_full_wav(
     }
 
     writer.finalize()?;
+    let elapsed = start_time.elapsed().as_secs_f32();
+    println!("Total generation time: {:.2}s", elapsed);
     Ok(())
 }

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -163,6 +163,7 @@ fn render_full_wav(track_json_str: String, out_path: String) -> PyResult<()> {
 
     let mut writer = WavWriter::create(&out_path, spec)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+    let start_time = std::time::Instant::now();
 
     let mut remaining = target_frames;
     let mut buffer = vec![0.0f32; 512 * 2];
@@ -178,6 +179,8 @@ fn render_full_wav(track_json_str: String, out_path: String) -> PyResult<()> {
     }
 
     writer.finalize().map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+    let elapsed = start_time.elapsed().as_secs_f32();
+    println!("Total generation time: {:.2}s", elapsed);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- report generation time after track rendering in the realtime backend
- print the same information in the CLI rendering tool

## Testing
- `cargo test` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865da142a80832d968111f82f04ef6d