### PR TITLE
Add .noise file support in realtime backend

### DIFF
--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod audio_io;
 pub mod dsp;
 pub mod models;
+pub mod noise_params;
 pub mod scheduler;
 pub mod command;
 pub mod voices;

--- a/src/audio/realtime_backend/src/noise_params.rs
+++ b/src/audio/realtime_backend/src/noise_params.rs
@@ -1,0 +1,63 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct NoiseSweep {
+    #[serde(default)]
+    pub start_min: f32,
+    #[serde(default)]
+    pub end_min: f32,
+    #[serde(default)]
+    pub start_max: f32,
+    #[serde(default)]
+    pub end_max: f32,
+    #[serde(default)]
+    pub start_q: f32,
+    #[serde(default)]
+    pub end_q: f32,
+    #[serde(default)]
+    pub start_casc: usize,
+    #[serde(default)]
+    pub end_casc: usize,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct NoiseParams {
+    #[serde(default)]
+    pub duration_seconds: f32,
+    #[serde(default)]
+    pub sample_rate: u32,
+    #[serde(default)]
+    pub noise_type: String,
+    #[serde(default)]
+    pub lfo_waveform: String,
+    #[serde(default)]
+    pub transition: bool,
+    #[serde(default)]
+    pub lfo_freq: f32,
+    #[serde(default)]
+    pub start_lfo_freq: f32,
+    #[serde(default)]
+    pub end_lfo_freq: f32,
+    #[serde(default)]
+    pub sweeps: Vec<NoiseSweep>,
+    #[serde(default)]
+    pub start_lfo_phase_offset_deg: f32,
+    #[serde(default)]
+    pub end_lfo_phase_offset_deg: f32,
+    #[serde(default)]
+    pub start_intra_phase_offset_deg: f32,
+    #[serde(default)]
+    pub end_intra_phase_offset_deg: f32,
+    #[serde(default)]
+    pub initial_offset: f32,
+    #[serde(default)]
+    pub post_offset: f32,
+    #[serde(default)]
+    pub input_audio_path: String,
+}
+
+pub fn load_noise_params(path: &str) -> Result<NoiseParams, Box<dyn std::error::Error>> {
+    let file = std::fs::File::open(path)?;
+    let params: NoiseParams = serde_json::from_reader(file)?;
+    Ok(params)
+}

--- a/src/audio/realtime_backend/src/scheduler.rs
+++ b/src/audio/realtime_backend/src/scheduler.rs
@@ -198,21 +198,65 @@ impl TrackScheduler {
         let background_noise = if let Some(noise_cfg) = &track.background_noise {
             let total_duration: f64 = track.steps.iter().map(|s| s.duration).sum();
             let total_samples = (total_duration * sample_rate as f64) as usize;
-            let samples = match noise_cfg.noise_type.to_lowercase().as_str() {
-                "brown" => generate_brown_noise_samples(total_samples),
-                "swept_notch" => generate_swept_notch_noise(
-                    total_duration as f32,
-                    device_rate,
-                    1.0 / 12.0,
-                    &[(1000.0, 10000.0)],
-                    &[25.0],
-                    &[10],
-                    90.0,
-                    0.0,
-                    "pink",
-                    "sine",
-                ),
-                _ => generate_pink_noise_samples(total_samples),
+            let samples = if !noise_cfg.file_path.is_empty()
+                && noise_cfg.file_path.ends_with(".noise")
+            {
+                if let Ok(params) = crate::noise_params::load_noise_params(&noise_cfg.file_path) {
+                    let lfo_freq = if params.transition {
+                        params.start_lfo_freq
+                    } else {
+                        if params.lfo_freq != 0.0 {
+                            params.lfo_freq
+                        } else {
+                            1.0 / 12.0
+                        }
+                    };
+                    let sweeps: Vec<(f32, f32)> = if !params.sweeps.is_empty() {
+                        params
+                            .sweeps
+                            .iter()
+                            .map(|sw| (sw.start_min.max(1.0), sw.start_max.max(sw.start_min + 1.0)))
+                            .collect()
+                    } else {
+                        vec![(1000.0, 10000.0)]
+                    };
+                    let qs = vec![25.0; sweeps.len()];
+                    let casc = vec![10usize; sweeps.len()];
+                    generate_swept_notch_noise(
+                        total_duration as f32,
+                        device_rate,
+                        lfo_freq,
+                        &sweeps,
+                        &qs,
+                        &casc,
+                        params.start_lfo_phase_offset_deg,
+                        params.start_intra_phase_offset_deg,
+                        &params.noise_type,
+                        &params.lfo_waveform,
+                    )
+                } else {
+                    match noise_cfg.noise_type.to_lowercase().as_str() {
+                        "brown" => generate_brown_noise_samples(total_samples),
+                        _ => generate_pink_noise_samples(total_samples),
+                    }
+                }
+            } else {
+                match noise_cfg.noise_type.to_lowercase().as_str() {
+                    "brown" => generate_brown_noise_samples(total_samples),
+                    "swept_notch" => generate_swept_notch_noise(
+                        total_duration as f32,
+                        device_rate,
+                        1.0 / 12.0,
+                        &[(1000.0, 10000.0)],
+                        &[25.0],
+                        &[10],
+                        90.0,
+                        0.0,
+                        "pink",
+                        "sine",
+                    ),
+                    _ => generate_pink_noise_samples(total_samples),
+                }
             };
             let mut stereo = Vec::with_capacity(samples.len() * 2);
             for s in samples {
@@ -285,21 +329,57 @@ impl TrackScheduler {
         self.background_noise = if let Some(noise_cfg) = &track.background_noise {
             let total_duration: f64 = track.steps.iter().map(|s| s.duration).sum();
             let total_samples = (total_duration * self.sample_rate as f64) as usize;
-            let samples = match noise_cfg.noise_type.to_lowercase().as_str() {
-                "brown" => generate_brown_noise_samples(total_samples),
-                "swept_notch" => generate_swept_notch_noise(
-                    total_duration as f32,
-                    self.sample_rate as u32,
-                    1.0 / 12.0,
-                    &[(1000.0, 10000.0)],
-                    &[25.0],
-                    &[10],
-                    90.0,
-                    0.0,
-                    "pink",
-                    "sine",
-                ),
-                _ => generate_pink_noise_samples(total_samples),
+            let samples = if !noise_cfg.file_path.is_empty()
+                && noise_cfg.file_path.ends_with(".noise")
+            {
+                if let Ok(params) = crate::noise_params::load_noise_params(&noise_cfg.file_path) {
+                    let lfo_freq = if params.transition { params.start_lfo_freq } else { if params.lfo_freq != 0.0 { params.lfo_freq } else { 1.0 / 12.0 } };
+                    let sweeps: Vec<(f32, f32)> = if !params.sweeps.is_empty() {
+                        params
+                            .sweeps
+                            .iter()
+                            .map(|sw| (sw.start_min.max(1.0), sw.start_max.max(sw.start_min + 1.0)))
+                            .collect()
+                    } else {
+                        vec![(1000.0, 10000.0)]
+                    };
+                    let qs = vec![25.0; sweeps.len()];
+                    let casc = vec![10usize; sweeps.len()];
+                    generate_swept_notch_noise(
+                        total_duration as f32,
+                        self.sample_rate as u32,
+                        lfo_freq,
+                        &sweeps,
+                        &qs,
+                        &casc,
+                        params.start_lfo_phase_offset_deg,
+                        params.start_intra_phase_offset_deg,
+                        &params.noise_type,
+                        &params.lfo_waveform,
+                    )
+                } else {
+                    match noise_cfg.noise_type.to_lowercase().as_str() {
+                        "brown" => generate_brown_noise_samples(total_samples),
+                        _ => generate_pink_noise_samples(total_samples),
+                    }
+                }
+            } else {
+                match noise_cfg.noise_type.to_lowercase().as_str() {
+                    "brown" => generate_brown_noise_samples(total_samples),
+                    "swept_notch" => generate_swept_notch_noise(
+                        total_duration as f32,
+                        self.sample_rate as u32,
+                        1.0 / 12.0,
+                        &[(1000.0, 10000.0)],
+                        &[25.0],
+                        &[10],
+                        90.0,
+                        0.0,
+                        "pink",
+                        "sine",
+                    ),
+                    _ => generate_pink_noise_samples(total_samples),
+                }
             };
             let mut stereo = Vec::with_capacity(samples.len() * 2);
             for s in samples {


### PR DESCRIPTION
## Summary
- add `noise_params` module for parsing `.noise` JSON files
- load `.noise` files in `TrackScheduler` for background noise generation
- expose new module in realtime backend library

## Testing
- `cargo check --manifest-path src/audio/realtime_backend/Cargo.toml`
- `cargo test --manifest-path src/audio/realtime_backend/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_686698851dbc832da96edd9180f1411a