### PR TITLE
Add start time parameter to realtime backend

### DIFF
--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -36,7 +36,8 @@ This produces a `realtime_backend` extension that can be imported from Python:
 import realtime_backend
 
 # `track_json` should be a JSON string exported by the GUI
-realtime_backend.start_stream(track_json)
+# start playback 30 seconds into the track
+realtime_backend.start_stream(track_json, start_time=30.0)
 
 # Render a 60 second sample to a wav file
 realtime_backend.render_sample_wav(track_json, "sample.wav")

--- a/src/audio/realtime_backend/WASM_GUIDE.md
+++ b/src/audio/realtime_backend/WASM_GUIDE.md
@@ -34,9 +34,10 @@ Import the generated module and initialize it before starting audio playback:
 ```javascript
 import init, { start_stream, stop_stream } from './realtime_backend.js';
 
-async function initAudio(trackJson) {
+async function initAudio(trackJson, sampleRate) {
   await init(); // loads realtime_backend_bg.wasm
-  await start_stream(JSON.stringify(trackJson));
+  // begin playback 10 seconds into the track
+  await start_stream(JSON.stringify(trackJson), sampleRate, 10.0);
 }
 ```
 


### PR DESCRIPTION
## Summary
- allow realtime audio engine to start playback from an arbitrary time
- expose optional `start_time` in Python and WebAssembly bindings
- update scheduler with a seeking helper
- document the new parameter in README and WASM guide

## Testing
- `cargo check`
- `cargo test`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68669f1a0b2c832d87ac2aee6e70c5cb