### PR TITLE
Expose playback progress and control in WASM

### DIFF
--- a/src/audio/realtime_backend/WASM_GUIDE.md
+++ b/src/audio/realtime_backend/WASM_GUIDE.md
@@ -32,7 +32,14 @@ This document explains how to compile the Rust based realtime DSP backend into a
 Import the generated module and initialize it before starting audio playback:
 
 ```javascript
-import init, { start_stream, stop_stream } from './realtime_backend.js';
+import init, {
+  start_stream,
+  stop_stream,
+  pause_stream,
+  resume_stream,
+  current_step,
+  elapsed_samples
+} from './realtime_backend.js';
 
 async function initAudio(trackJson) {
   await init(); // loads realtime_backend_bg.wasm
@@ -41,6 +48,7 @@ async function initAudio(trackJson) {
 ```
 
 The exported functions mirror the Python bindings. `start_stream` begins playback using the Web Audio API under the hood, while `stop_stream` halts it.
+`pause_stream` temporarily silences output without losing playback position and `resume_stream` continues from where it left off. You can poll progress using `current_step()` and `elapsed_samples()`.
 
 ### Performance Notes
 

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -248,6 +248,50 @@ pub fn process_block(frame_count: usize) -> js_sys::Float32Array {
 
 #[cfg(feature = "web")]
 #[wasm_bindgen]
+pub fn current_step() -> usize {
+    let mut step = 0usize;
+    WASM_SCHED.with(|s| {
+        if let Some((sched, _)) = &*s.borrow() {
+            step = sched.current_step_index();
+        }
+    });
+    step
+}
+
+#[cfg(feature = "web")]
+#[wasm_bindgen]
+pub fn elapsed_samples() -> u64 {
+    let mut samples = 0u64;
+    WASM_SCHED.with(|s| {
+        if let Some((sched, _)) = &*s.borrow() {
+            samples = sched.elapsed_samples();
+        }
+    });
+    samples
+}
+
+#[cfg(feature = "web")]
+#[wasm_bindgen]
+pub fn pause_stream() {
+    WASM_SCHED.with(|s| {
+        if let Some((sched, _)) = &mut *s.borrow_mut() {
+            sched.pause();
+        }
+    });
+}
+
+#[cfg(feature = "web")]
+#[wasm_bindgen]
+pub fn resume_stream() {
+    WASM_SCHED.with(|s| {
+        if let Some((sched, _)) = &mut *s.borrow_mut() {
+            sched.resume();
+        }
+    });
+}
+
+#[cfg(feature = "web")]
+#[wasm_bindgen]
 pub fn stop_stream() {
     *ENGINE_STATE.lock() = None;
     WASM_SCHED.with(|s| *s.borrow_mut() = None);

--- a/src/audio/realtime_backend/src/scheduler.rs
+++ b/src/audio/realtime_backend/src/scheduler.rs
@@ -71,6 +71,8 @@ pub struct TrackScheduler {
     pub next_step_sample: usize,
     pub crossfade_active: bool,
     pub absolute_sample: u64,
+    /// Whether playback is paused
+    pub paused: bool,
     pub clips: Vec<LoadedClip>,
     pub background_noise: Option<BackgroundNoise>,
     pub scratch: Vec<f32>,
@@ -271,6 +273,7 @@ impl TrackScheduler {
             next_step_sample: 0,
             crossfade_active: false,
             absolute_sample: 0,
+            paused: false,
             clips,
             background_noise,
             scratch: Vec::new(),
@@ -404,9 +407,33 @@ impl TrackScheduler {
         }
     }
 
+    pub fn pause(&mut self) {
+        self.paused = true;
+    }
+
+    pub fn resume(&mut self) {
+        self.paused = false;
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.paused
+    }
+
+    pub fn current_step_index(&self) -> usize {
+        self.current_step
+    }
+
+    pub fn elapsed_samples(&self) -> u64 {
+        self.absolute_sample
+    }
+
     pub fn process_block(&mut self, buffer: &mut [f32]) {
         let frame_count = buffer.len() / 2;
         buffer.fill(0.0);
+
+        if self.paused {
+            return;
+        }
 
         if self.current_step >= self.track.steps.len() {
             return;


### PR DESCRIPTION
## Summary
- allow pausing and resuming the realtime scheduler
- expose elapsed sample and current step counters
- add corresponding WASM bindings
- document new WebAssembly interface in the guide

## Testing
- `cargo check --manifest-path src/audio/realtime_backend/Cargo.toml --lib --no-default-features --features web`

------
https://chatgpt.com/codex/tasks/task_e_6866a0d3d408832d8dad5840652bca47