### PR TITLE
Fix realtime_backend generate output path

### DIFF
--- a/src/audio/realtime_backend/src/bin/realtime_backend.rs
+++ b/src/audio/realtime_backend/src/bin/realtime_backend.rs
@@ -166,6 +166,10 @@ fn render_full_wav(
         CONFIG.output_dir.join(out_path)
     };
 
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
     let mut writer = WavWriter::create(&output_path, spec)?;
     let start_time = std::time::Instant::now();
     let mut remaining = target_frames;

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -150,6 +150,11 @@ fn render_sample_wav(track_json_str: String, out_path: String) -> PyResult<()> {
         CONFIG.output_dir.join(&out_path)
     };
 
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+    }
+
     let mut writer = WavWriter::create(&output_path, spec)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
 
@@ -197,6 +202,11 @@ fn render_full_wav(track_json_str: String, out_path: String) -> PyResult<()> {
     } else {
         CONFIG.output_dir.join(&out_path)
     };
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+    }
 
     let mut writer = WavWriter::create(&output_path, spec)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;


### PR DESCRIPTION
## Summary
- ensure output directories exist when rendering WAVs

## Testing
- `cargo test --manifest-path src/audio/realtime_backend/Cargo.toml --quiet` *(fails: alsa library not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5420d90832d9a86288de1eae293