### PR TITLE
Add start_from seeking to realtime backend

### DIFF
--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -46,7 +46,8 @@ realtime_backend.render_sample_wav(track_json, "sample.wav")
 realtime_backend.render_full_wav(track_json, "full_output.wav")
 ```
 Call `realtime_backend.pause_stream()` to temporarily silence playback,
-`resume_stream()` to continue, and `stop_stream()` to halt playback entirely.
+`resume_stream()` to continue, `start_from(seconds)` to seek during
+playback, and `stop_stream()` to halt playback entirely.
 
 ## WebAssembly Build
 
@@ -67,13 +68,13 @@ binary. Pass the path to a track JSON file and optionally enable full
 rendering:
 
 ```bash
-cargo run --bin realtime_backend -- --path path/to/track.json --generate false
+cargo run --bin realtime_backend -- --path path/to/track.json --start 10.0 --generate false
 ```
 
 Use the `--gpu` flag to enable GPU acceleration (build with `--features gpu`):
 
 ```bash
-cargo run --bin realtime_backend --features gpu -- --path path/to/track.json --gpu true
+cargo run --bin realtime_backend --features gpu -- --path path/to/track.json --start 10.0 --gpu true
 ```
 
 If `--generate true` is supplied, the entire track is written to the
@@ -108,12 +109,13 @@ Each command also has its own help output.
 `run` accepts the path to a track JSON file and optional flags:
 
 ```text
-Usage: realtime_backend run --path <PATH> [--generate <BOOL>] [--gpu <BOOL>]
+Usage: realtime_backend run --path <PATH> [--generate <BOOL>] [--gpu <BOOL>] [--start <SECONDS>]
 
 Options:
   --path <PATH>          Path to the track JSON file
   --generate <BOOL>      Generate the full track to the output file instead of streaming [default: false]
   --gpu <BOOL>           Enable GPU accelerated mixing (requires building with `--features gpu`) [default: false]
+  --start <SECONDS>      Start playback at the given time in seconds [default: 0]
   -h, --help             Print help
 ```
 

--- a/src/audio/realtime_backend/src/bin/realtime_backend.rs
+++ b/src/audio/realtime_backend/src/bin/realtime_backend.rs
@@ -36,6 +36,9 @@ struct RunArgs {
     /// Enable GPU accelerated mixing (requires building with `--features gpu`)
     #[arg(long, default_value_t = false)]
     gpu: bool,
+    /// Start playback from this time in seconds
+    #[arg(long, default_value_t = 0.0)]
+    start: f64,
 }
 
 #[derive(ClapArgs)]
@@ -84,7 +87,7 @@ fn run_command(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let cfg = device.default_output_config()?;
     let stream_rate = cfg.sample_rate().0;
 
-    let mut scheduler = TrackScheduler::new(track_data, stream_rate);
+    let mut scheduler = TrackScheduler::new_with_start(track_data, stream_rate, args.start);
     scheduler.gpu_enabled = if args.gpu { true } else { CONFIG.gpu };
     let rb = HeapRb::<Command>::new(1024);
     let (mut prod, cons) = rb.split();

--- a/src/audio/realtime_backend/src/command.rs
+++ b/src/audio/realtime_backend/src/command.rs
@@ -7,4 +7,6 @@ pub enum Command {
     EnableGpu(bool),
     /// Pause or resume playback
     SetPaused(bool),
+    /// Seek to a new playback position in seconds
+    StartFrom(f64),
 }

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -123,6 +123,15 @@ fn resume_stream() -> PyResult<()> {
 
 #[cfg(feature = "python")]
 #[pyfunction]
+fn start_from(position: f64) -> PyResult<()> {
+    if let Some(prod) = &mut *ENGINE_STATE.lock() {
+        let _ = prod.try_push(Command::StartFrom(position));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
 fn render_sample_wav(track_json_str: String, out_path: String) -> PyResult<()> {
     use hound::{WavSpec, WavWriter, SampleFormat};
     let track_data: TrackData = serde_json::from_str(&track_json_str)
@@ -308,6 +317,14 @@ pub fn resume_stream() {
 
 #[cfg(feature = "web")]
 #[wasm_bindgen]
+pub fn start_from(position: f64) {
+    if let Some(prod) = &mut *ENGINE_STATE.lock() {
+        let _ = prod.try_push(Command::StartFrom(position));
+    }
+}
+
+#[cfg(feature = "web")]
+#[wasm_bindgen]
 pub fn stop_stream() {
     *ENGINE_STATE.lock() = None;
     WASM_SCHED.with(|s| *s.borrow_mut() = None);
@@ -320,6 +337,7 @@ fn realtime_backend(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(stop_stream, m)?)?;
     m.add_function(wrap_pyfunction!(pause_stream, m)?)?;
     m.add_function(wrap_pyfunction!(resume_stream, m)?)?;
+    m.add_function(wrap_pyfunction!(start_from, m)?)?;
     m.add_function(wrap_pyfunction!(update_track, m)?)?;
     m.add_function(wrap_pyfunction!(render_sample_wav, m)?)?;
     m.add_function(wrap_pyfunction!(render_full_wav, m)?)?;

--- a/src/audio/realtime_backend/src/scheduler.rs
+++ b/src/audio/realtime_backend/src/scheduler.rs
@@ -430,6 +430,10 @@ impl TrackScheduler {
                     self.resume();
                 }
             }
+            Command::StartFrom(time) => {
+                let samples = (time * self.sample_rate as f64) as usize;
+                self.seek_samples(samples);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce `StartFrom` command for repositioning playback
- expose `start_from` to Python and wasm callers
- add `--start` CLI option to begin playback from a given time
- update scheduler to handle the new command
- document new functionality in realtime backend README

## Testing
- `cargo check` *(fails: the system library `alsa` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b5edadd0832db41d713ac275a09c