### PR TITLE
Restrict GPU usage to file rendering

### DIFF
--- a/src/audio/realtime_backend/README.md
+++ b/src/audio/realtime_backend/README.md
@@ -70,16 +70,18 @@ rendering:
 cargo run --bin realtime_backend -- --path path/to/track.json --generate false
 ```
 
-Use the `--gpu` flag to enable GPU acceleration (build with `--features gpu`):
+Use the `--gpu` flag to enable GPU acceleration when rendering to a file
+(build with `--features gpu`):
 
 ```bash
 cargo run --bin realtime_backend --features gpu -- --path path/to/track.json --gpu true
 ```
 
-If `--generate true` is supplied, the entire track is written to the
-`outputFilename` specified in the JSON. Otherwise it streams the audio directly
-to the default output device. While running you can press `p` to toggle
-pause/resume, `q` to quit, or hit `Ctrl+C`.
+GPU acceleration is applied only when `--generate true` is used. Streaming
+playback always runs on the CPU. If `--generate true` is supplied, the entire
+track is written to the `outputFilename` specified in the JSON. Otherwise it
+streams the audio directly to the default output device. While running you can
+press `p` to toggle pause/resume, `q` to quit, or hit `Ctrl+C`.
 
 To create a default `config.toml` in the current directory run:
 
@@ -131,7 +133,7 @@ Options:
 
 The backend includes an experimental GPU mixing path behind the `gpu` Cargo
 feature. When enabled, a compute shader is used to sum the active voice buffers
-for each processed block.
+for each processed block during file generation only.
 
 Build the library with GPU support using:
 

--- a/src/audio/realtime_backend/src/bin/realtime_backend.rs
+++ b/src/audio/realtime_backend/src/bin/realtime_backend.rs
@@ -85,7 +85,9 @@ fn run_command(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let stream_rate = cfg.sample_rate().0;
 
     let mut scheduler = TrackScheduler::new(track_data, stream_rate);
-    scheduler.gpu_enabled = if args.gpu { true } else { CONFIG.gpu };
+    // GPU acceleration is reserved for file generation. Disable it during
+    // realtime streaming to avoid extra overhead.
+    scheduler.gpu_enabled = false;
     let rb = HeapRb::<Command>::new(1024);
     let (mut prod, cons) = rb.split();
     let (tx, rx) = unbounded();
@@ -146,7 +148,9 @@ fn render_full_wav(
     use hound::{WavSpec, WavWriter, SampleFormat};
     let sample_rate = track_data.global_settings.sample_rate;
     let mut scheduler = TrackScheduler::new(track_data.clone(), sample_rate);
-    scheduler.gpu_enabled = if gpu { true } else { CONFIG.gpu };
+    // Use the GPU when rendering if requested by the caller. Streaming never
+    // enables GPU acceleration.
+    scheduler.gpu_enabled = gpu;
     let target_frames: usize = track_data
         .steps
         .iter()

--- a/src/audio/realtime_backend/src/lib.rs
+++ b/src/audio/realtime_backend/src/lib.rs
@@ -59,7 +59,9 @@ fn start_stream(track_json_str: String, start_time: Option<f64>) -> PyResult<()>
 
     let start_secs = start_time.unwrap_or(0.0);
     let mut scheduler = TrackScheduler::new_with_start(track_data, stream_rate, start_secs);
-    scheduler.gpu_enabled = CONFIG.gpu;
+    // Disable GPU usage for realtime playback. GPU acceleration is reserved
+    // for offline rendering to avoid unnecessary overhead during streaming.
+    scheduler.gpu_enabled = false;
     let rb = HeapRb::<Command>::new(1024);
     let (prod, cons) = rb.split();
     *ENGINE_STATE.lock() = Some(prod);
@@ -130,6 +132,9 @@ fn render_sample_wav(track_json_str: String, out_path: String) -> PyResult<()> {
 
     let sample_rate = track_data.global_settings.sample_rate;
     let mut scheduler = TrackScheduler::new(track_data.clone(), sample_rate);
+    // Use GPU acceleration when rendering to a file if available.
+    // Streaming paths keep GPU disabled.
+    scheduler.gpu_enabled = true;
     let track_frames: usize = track_data
         .steps
         .iter()
@@ -184,6 +189,8 @@ fn render_full_wav(track_json_str: String, out_path: String) -> PyResult<()> {
 
     let sample_rate = track_data.global_settings.sample_rate;
     let mut scheduler = TrackScheduler::new(track_data.clone(), sample_rate);
+    // Enable GPU acceleration during full track rendering if available.
+    scheduler.gpu_enabled = true;
     let target_frames: usize = track_data
         .steps
         .iter()


### PR DESCRIPTION
## Summary
- use CPU for realtime playback
- enable GPU during file generation only
- update docs about GPU usage

## Testing
- `python3 -m compileall -q src/audio`
- `cargo check` *(fails: `alsa.pc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b7957614832d9adf177452d693bf