### PR TITLE
Fix noise preset path resolution

### DIFF
--- a/src/audio/realtime_backend/src/bin/play_json.rs
+++ b/src/audio/realtime_backend/src/bin/play_json.rs
@@ -19,7 +19,10 @@ struct Args {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
     let json_str = std::fs::read_to_string(&args.track_file)?;
-    let track_data: TrackData = serde_json::from_str(&json_str)?;
+    let mut track_data: TrackData = serde_json::from_str(&json_str)?;
+    if let Some(dir) = std::path::Path::new(&args.track_file).parent() {
+        track_data.resolve_relative_paths(dir);
+    }
 
     let host = cpal::default_host();
     let device = host

--- a/src/audio/realtime_backend/src/bin/realtime_backend.rs
+++ b/src/audio/realtime_backend/src/bin/realtime_backend.rs
@@ -62,7 +62,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn run_command(args: RunArgs) -> Result<(), Box<dyn std::error::Error>> {
     let json_str = std::fs::read_to_string(&args.path)?;
-    let track_data: TrackData = serde_json::from_str(&json_str)?;
+    let mut track_data: TrackData = serde_json::from_str(&json_str)?;
+    if let Some(dir) = std::path::Path::new(&args.path).parent() {
+        track_data.resolve_relative_paths(dir);
+    }
 
     if args.generate {
         let out_name = track_data

--- a/src/audio/realtime_backend/src/models.rs
+++ b/src/audio/realtime_backend/src/models.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::path::Path;
 
 fn default_crossfade_duration() -> f64 { 3.0 }
 fn default_crossfade_curve() -> String { "linear".to_string() }
@@ -76,4 +77,27 @@ pub struct BackgroundNoiseData {
     pub noise_type: String,
     #[serde(default, alias = "gain", alias = "amp")]
     pub amp: f32,
+}
+
+impl TrackData {
+    /// Resolve clip and noise file paths relative to the provided base directory.
+    pub fn resolve_relative_paths<P: AsRef<Path>>(&mut self, base: P) {
+        let base = base.as_ref();
+        if let Some(noise) = &mut self.background_noise {
+            if !noise.file_path.is_empty() {
+                let p = Path::new(&noise.file_path);
+                if p.is_relative() {
+                    noise.file_path = base.join(p).to_string_lossy().into_owned();
+                }
+            }
+        }
+        for clip in &mut self.clips {
+            if !clip.file_path.is_empty() {
+                let p = Path::new(&clip.file_path);
+                if p.is_relative() {
+                    clip.file_path = base.join(p).to_string_lossy().into_owned();
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- fix .noise file not being found
- add `resolve_relative_paths` on `TrackData`
- use it in realtime backend CLIs

## Testing
- `cargo check` *(fails: The system library `alsa` required by crate `alsa-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd512434832db01f7f302a716e8c