### PR TITLE
Undo realtime backend vectorization

### DIFF
--- a/audio/src/realtime_backend/src/dsp/mod.rs
+++ b/audio/src/realtime_backend/src/dsp/mod.rs
@@ -12,8 +12,8 @@ pub fn generate_pink_noise_samples(n_samples: usize) -> Vec<f32> {
     let mut b3 = 0.0f32;
     let mut b4 = 0.0f32;
     let mut b5 = 0.0f32;
-    let mut out = vec![0.0f32; n_samples];
-    for val in &mut out {
+    let mut out = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
         let w = rng.gen::<f32>();
         b0 = 0.99886 * b0 + w * 0.0555179;
         b1 = 0.99332 * b1 + w * 0.0750759;
@@ -21,7 +21,7 @@ pub fn generate_pink_noise_samples(n_samples: usize) -> Vec<f32> {
         b3 = 0.86650 * b3 + w * 0.3104856;
         b4 = 0.55000 * b4 + w * 0.5329522;
         b5 = -0.7616 * b5 - w * 0.0168980;
-        *val = (b0 + b1 + b2 + b3 + b4 + b5) * 0.11;
+        out.push((b0 + b1 + b2 + b3 + b4 + b5) * 0.11);
     }
     out
 }
@@ -29,10 +29,10 @@ pub fn generate_pink_noise_samples(n_samples: usize) -> Vec<f32> {
 pub fn generate_brown_noise_samples(n_samples: usize) -> Vec<f32> {
     let mut rng = rand::thread_rng();
     let mut cumulative = 0.0f32;
-    let mut out = vec![0.0f32; n_samples];
-    for val in &mut out {
+    let mut out = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
         cumulative += rng.gen::<f32>() - 0.5;
-        *val = cumulative;
+        out.push(cumulative);
     }
     let max_abs = out.iter().cloned().fold(0.0f32, |a, b| a.max(b.abs()));
     if max_abs > 0.0 {


### PR DESCRIPTION
## Summary
- revert vectorized loops in `voices.rs`
- undo preallocated vector optimizations in noise generation

## Testing
- `cargo check` *(fails: alsa-sys build script missing system library)*

------
https://chatgpt.com/codex/tasks/task_e_686723444d24832db3df4b30b2b6063e