### PR TITLE
Update web_ui with wasm sync helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ node_modules/
 audio/src/audio/web_ui/dist/
 audio/src/audio/realtime_backend/Cargo.lock
 audio/src/audio/realtime_backend/target/
+audio/src/web_ui/public/pkg/
+audio/src/realtime_backend/pkg/
 

--- a/audio/src/web_ui/README.md
+++ b/audio/src/web_ui/README.md
@@ -12,8 +12,9 @@ from a web page.
    cd ../realtime_backend
    wasm-pack build --target web --release --no-default-features --features web
    ```
-3. Copy the generated `pkg` folder into `public/` so Vite can serve
-    `realtime_backend.js` and `realtime_backend_bg.wasm`.
+3. Run `npm run sync-wasm` (or any of the dev/build scripts) to copy the
+   generated `pkg` folder into `public/` so Vite can serve
+   `realtime_backend.js` and `realtime_backend_bg.wasm`.
 
 ## Running the Demo
 
@@ -23,6 +24,9 @@ Install the npm dependencies and start the development server. **Vite 5 requires
 npm install
 npm run dev
 ```
+
+`npm run dev` will automatically copy the latest WASM build from
+`../realtime_backend/pkg` into the `public/pkg` directory before starting Vite.
 
 Vite will serve the application at the printed URL. You can either paste a track
 JSON object into the text box or use the **Upload** field to load a `.json`

--- a/audio/src/web_ui/package.json
+++ b/audio/src/web_ui/package.json
@@ -8,8 +8,9 @@
   },
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "sync-wasm": "node ./sync-wasm.js",
+    "dev": "npm run sync-wasm && vite",
+    "build": "npm run sync-wasm && vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/audio/src/web_ui/sync-wasm.js
+++ b/audio/src/web_ui/sync-wasm.js
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { cpSync, rmSync, existsSync } from 'fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const srcDir = resolve(__dirname, '../realtime_backend/pkg');
+const destDir = resolve(__dirname, 'public/pkg');
+
+if (!existsSync(srcDir)) {
+  console.error(`WASM package not found at ${srcDir}. Build it with wasm-pack first.`);
+  process.exit(1);
+}
+
+rmSync(destDir, { recursive: true, force: true });
+cpSync(srcDir, destDir, { recursive: true });
+console.log(`Copied WASM package from ${srcDir} to ${destDir}`);


### PR DESCRIPTION
## Summary
- sync the latest realtime_backend wasm files into the web UI
- invoke the sync step automatically from npm scripts
- mention the new workflow in the web_ui README
- ignore generated wasm files

## Testing
- `npm run sync-wasm` *(fails: WASM package not found because it wasn't built yet)*

------
https://chatgpt.com/codex/tasks/task_e_6867582dad5c832d818f853bc154de12