### PR TITLE
Fix Vite import path for WASM package

### DIFF
--- a/audio/src/web_ui/README.md
+++ b/audio/src/web_ui/README.md
@@ -15,6 +15,12 @@ from a web page.
 3. Run `npm run sync-wasm` (or any of the dev/build scripts) to copy the
    generated `pkg` folder into `public/` so Vite can serve
    `realtime_backend.js` and `realtime_backend_bg.wasm`.
+   When importing the module in JavaScript, append `?import` to the path
+   so Vite treats it as an ES module:
+
+   ```javascript
+   import init from '/pkg/realtime_backend.js?import';
+   ```
 
 ## Running the Demo
 

--- a/audio/src/web_ui/src/main.js
+++ b/audio/src/web_ui/src/main.js
@@ -9,7 +9,7 @@ import init, {
   enable_gpu,
   current_step,
   elapsed_samples,
-} from '/pkg/realtime_backend.js';
+} from '/pkg/realtime_backend.js?import';
 import SharedRingBuffer from './ringbuffer.js';
 
 let audioCtx = null;


### PR DESCRIPTION
## Summary
- fix realtime_backend import path for Vite 5
- document `?import` requirement in Web UI README

## Testing
- `npm install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675a744460832dbbb476447f90148d