### PR TITLE
Add overlay clip upload to web UI

### DIFF
--- a/audio/src/web_ui/index.html
+++ b/audio/src/web_ui/index.html
@@ -8,6 +8,7 @@
   <h1>Realtime Backend Web Demo</h1>
   <input type="file" id="json-upload" accept=".json"><br>
   <input type="file" id="noise-upload" accept=".noise"><br>
+  <input type="file" id="clip-upload" accept=".wav,.flac,.mp3" multiple><br>
   <textarea id="track-json" rows="10" cols="80">{\n  \"global\": {\"sample_rate\": 44100},\n  \"progression\": [],\n  \"background_noise\": {},\n  \"overlay_clips\": []\n}</textarea><br>
   <label>Start time (s): <input id="start-time" type="number" step="0.1" value="0"></label><br>
   <label><input type="checkbox" id="gpu-enable"> Enable GPU</label><br>

--- a/audio/src/web_ui/src/main.js
+++ b/audio/src/web_ui/src/main.js
@@ -223,3 +223,24 @@ document.getElementById('noise-upload').addEventListener('change', (event) => {
   };
   reader.readAsText(file);
 });
+
+document.getElementById('clip-upload').addEventListener('change', (event) => {
+  const files = Array.from(event.target.files || []);
+  if (!files.length) return;
+  const textarea = document.getElementById('track-json');
+  let track;
+  try {
+    track = JSON.parse(textarea.value);
+  } catch (err) {
+    console.warn('Invalid track JSON, resetting');
+    track = { global: { sample_rate: 44100 }, progression: [], background_noise: {}, overlay_clips: [] };
+  }
+  if (!Array.isArray(track.overlay_clips)) {
+    track.overlay_clips = [];
+  }
+  for (const file of files) {
+    const url = URL.createObjectURL(file);
+    track.overlay_clips.push({ file_path: url, start: 0, amp: 1.0 });
+  }
+  textarea.value = JSON.stringify(track, null, 2);
+});


### PR DESCRIPTION
## Summary
- extend `index.html` with new overlay clip file input
- update web UI script to add uploaded clips to track JSON

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680494ebc4832dbabd6391b4b3ee2c