### PR TITLE
Implement dark-mode React UI with shadcn

### DIFF
--- a/audio/src/web_ui/index.html
+++ b/audio/src/web_ui/index.html
@@ -1,29 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Realtime Backend Web Demo</title>
-</head>
-<body>
-  <h1>Realtime Backend Web Demo</h1>
-  <input type="file" id="json-upload" accept=".json"><br>
-  <select id="track-select"></select> <button id="load-track">Load Track</button><br>
-  <input type="file" id="noise-upload" accept=".noise"><br>
-  <select id="noise-select"></select> <button id="load-noise">Insert Noise</button><br>
-  <input type="file" id="clip-upload" accept=".wav,.flac,.mp3" multiple><br>
-  <select id="clip-select" multiple></select> <button id="add-clip">Add Clip</button><br>
-  <textarea id="track-json" rows="10" cols="80">{\n  \"global\": {\"sample_rate\": 44100},\n  \"progression\": [],\n  \"background_noise\": {},\n  \"overlay_clips\": []\n}</textarea><br>
-  <label>Start time (s): <input id="start-time" type="number" step="0.1" value="0"></label><br>
-  <label><input type="checkbox" id="gpu-enable"> Enable GPU</label><br>
-  <button id="start">Start</button>
-  <button id="pause">Pause</button>
-  <button id="resume">Resume</button>
-  <button id="stop">Stop</button><br>
-  <label>Seek to (s): <input id="seek-time" type="number" step="0.1" value="0"></label>
-  <button id="seek-button">Seek</button>
-  <button id="update-track">Update Track</button>
-  <div>Current step: <span id="current-step">0</span></div>
-  <div>Elapsed samples: <span id="elapsed-samples">0</span></div>
-  <script type="module" src="/src/main.js"></script>
-</body>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Realtime Backend Web Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
 </html>

--- a/audio/src/web_ui/package.json
+++ b/audio/src/web_ui/package.json
@@ -14,6 +14,14 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.0",
     "vite": "^7.0.0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/audio/src/web_ui/postcss.config.js
+++ b/audio/src/web_ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/audio/src/web_ui/src/App.jsx
+++ b/audio/src/web_ui/src/App.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { Button } from './components/ui/button';
+import {
+  start,
+  stop,
+  pause,
+  resume,
+  seek,
+  sendUpdate,
+  toggleGpu,
+  loadTrackFromServer,
+  loadNoiseFromServer,
+  addClipFromServer,
+  initSelects,
+} from './main.js';
+
+export default function App() {
+  useEffect(() => {
+    initSelects();
+  }, []);
+
+  return (
+    <div className="p-4 space-y-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Realtime Backend Web Demo</h1>
+      <div className="space-y-2">
+        <input type="file" id="json-upload" accept=".json" className="block" />
+        <div className="flex space-x-2">
+          <select id="track-select" className="flex-1 bg-gray-800 p-2 rounded" />
+          <Button id="load-track" onClick={loadTrackFromServer}>Load Track</Button>
+        </div>
+        <input type="file" id="noise-upload" accept=".noise" className="block" />
+        <div className="flex space-x-2">
+          <select id="noise-select" className="flex-1 bg-gray-800 p-2 rounded" />
+          <Button id="load-noise" onClick={loadNoiseFromServer}>Insert Noise</Button>
+        </div>
+        <input type="file" id="clip-upload" accept=".wav,.flac,.mp3" multiple className="block" />
+        <div className="flex space-x-2">
+          <select id="clip-select" multiple className="flex-1 bg-gray-800 p-2 rounded" />
+          <Button id="add-clip" onClick={addClipFromServer}>Add Clip</Button>
+        </div>
+        <textarea id="track-json" rows="10" cols="80" className="w-full bg-gray-800 p-2 rounded" defaultValue={`{\n  "global": {"sample_rate": 44100},\n  "progression": [],\n  "background_noise": {},\n  "overlay_clips": []\n}`} />
+        <label className="block">Start time (s): <input id="start-time" type="number" step="0.1" defaultValue="0" className="ml-2 text-black" /></label>
+        <label className="block"><input type="checkbox" id="gpu-enable" className="mr-2" /> Enable GPU</label>
+        <div className="space-x-2">
+          <Button id="start" onClick={start}>Start</Button>
+          <Button id="pause" onClick={pause}>Pause</Button>
+          <Button id="resume" onClick={resume}>Resume</Button>
+          <Button id="stop" onClick={stop}>Stop</Button>
+        </div>
+        <div className="flex items-center space-x-2">
+          <label>Seek to (s): <input id="seek-time" type="number" step="0.1" defaultValue="0" className="ml-2 text-black" /></label>
+          <Button id="seek-button" onClick={seek}>Seek</Button>
+          <Button id="update-track" onClick={sendUpdate}>Update Track</Button>
+        </div>
+        <div>Current step: <span id="current-step">0</span></div>
+        <div>Elapsed samples: <span id="elapsed-samples">0</span></div>
+      </div>
+    </div>
+  );
+}

--- a/audio/src/web_ui/src/components/ui/button.jsx
+++ b/audio/src/web_ui/src/components/ui/button.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+export const buttonVariants = {
+  base: 'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+  primary: 'bg-blue-600 text-white hover:bg-blue-500',
+};
+
+export const Button = React.forwardRef(function Button({ className = '', variant = 'primary', ...props }, ref) {
+  const classes = cn(buttonVariants.base, buttonVariants[variant], className);
+  return <button ref={ref} className={classes} {...props} />;
+});

--- a/audio/src/web_ui/src/index.css
+++ b/audio/src/web_ui/src/index.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-900 text-gray-100;
+  }
+}

--- a/audio/src/web_ui/src/lib/utils.js
+++ b/audio/src/web_ui/src/lib/utils.js
@@ -1,0 +1,3 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/audio/src/web_ui/src/main.js
+++ b/audio/src/web_ui/src/main.js
@@ -319,7 +319,4 @@ function addClipFromServer() {
   textarea.value = JSON.stringify(track, null, 2);
 }
 
-initSelects();
-document.getElementById('load-track').addEventListener('click', loadTrackFromServer);
-document.getElementById('load-noise').addEventListener('click', loadNoiseFromServer);
-document.getElementById('add-clip').addEventListener('click', addClipFromServer);
+export { initSelects, loadTrackFromServer, loadNoiseFromServer, addClipFromServer };

--- a/audio/src/web_ui/src/main.jsx
+++ b/audio/src/web_ui/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/audio/src/web_ui/tailwind.config.js
+++ b/audio/src/web_ui/tailwind.config.js
@@ -1,0 +1,11 @@
+export default {
+  darkMode: 'class',
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/audio/src/web_ui/vite.config.js
+++ b/audio/src/web_ui/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   server: {
     open: true,
     // Add these headers to enable SharedArrayBuffer


### PR DESCRIPTION
## Summary
- add React and tailwind dependencies
- create simple shadcn-style Button component
- implement `App.jsx` React interface
- configure Vite with React plugin and Tailwind
- export utility functions from existing backend script

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869708c15f0832d9914875e487a38d0