### PR TITLE
Enable overlay clips in web demo

### DIFF
--- a/audio/src/realtime_backend/Cargo.toml
+++ b/audio/src/realtime_backend/Cargo.toml
@@ -38,6 +38,7 @@ hound = "3.5.1"
 wgpu = { version = "0.19", optional = true }
 pollster = { version = "0.3", optional = true }
 bytemuck = { version = "1.14", features = ["derive"], optional = true }
+base64 = "0.21"
 toml = "0.7"
 
 


### PR DESCRIPTION
## Summary
- allow uploading overlay clips as data URLs in the web UI
- fetch server clips as data URLs
- load `data:` URIs in the realtime backend scheduler
- add missing `base64` dependency

## Testing
- `cargo check --target wasm32-unknown-unknown --no-default-features --features web --lib`
- `cargo test --target wasm32-unknown-unknown --no-default-features --features web --lib` *(fails: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68697a5ee2fc832d838c1d4b3885b288