### PR TITLE
Fix ring buffer null errors in web UI

### DIFF
--- a/audio/src/web_ui/src/main.js
+++ b/audio/src/web_ui/src/main.js
@@ -94,6 +94,13 @@ async function setupAudio(sampleRate) {
   // 7️⃣ REFILL LOOP — keeps you topped up in small slices:
   // Use setInterval at ~5 ms so you stay ahead of the 128-frame (~2.9 ms) worklet callbacks.
   fillTimer = setInterval(() => {
+    // ringBuffer may be null if playback was stopped but an interval
+    // callback is still queued. Guard against accessing properties of
+    // a cleared buffer to avoid console errors.
+    if (!ringBuffer) {
+      return;
+    }
+
     let free = ringBuffer.availableWrite();
     // Write as many small, correctly‐sized chunks as will fit right now:
     while (free >= samplesPerFill) {


### PR DESCRIPTION
## Summary
- guard ring buffer usage in web UI when playback stops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697deb9804832d82461b5e31dd3523