### PR TITLE
Fix default noise amplitude in Web UI

### DIFF
--- a/audio/src/web_ui/src/main.js
+++ b/audio/src/web_ui/src/main.js
@@ -231,6 +231,9 @@ export function handleNoiseUpload(event) {
         track.background_noise = {};
       }
       track.background_noise.params = params;
+      if (track.background_noise.amp === undefined) {
+        track.background_noise.amp = 1.0;
+      }
       textarea.value = JSON.stringify(track, null, 2);
     } catch (err) {
       console.error('Failed to parse .noise file', err);
@@ -297,6 +300,9 @@ async function loadNoiseFromServer() {
     }
     if (!track.background_noise) track.background_noise = {};
     track.background_noise.params = params;
+    if (track.background_noise.amp === undefined) {
+      track.background_noise.amp = 1.0;
+    }
     textarea.value = JSON.stringify(track, null, 2);
   } catch (err) {
     console.error('Failed to load noise file', err);


### PR DESCRIPTION
## Summary
- ensure background noise is audible when inserted via Web UI
- add default amplitude of `1.0` when loading or uploading a `.noise` file

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68697e0b7f44832db1c4a935c8592284