### PR TITLE
Add React logo tester

### DIFF
--- a/audio/src/web_ui/.gitignore
+++ b/audio/src/web_ui/.gitignore
@@ -1,0 +1,2 @@
+dist/
+package-lock.json

--- a/audio/src/web_ui/logo.html
+++ b/audio/src/web_ui/logo.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logo Tester</title>
+  </head>
+  <body>
+    <div id="logo-root"></div>
+    <script type="module" src="/src/logo.jsx"></script>
+  </body>
+</html>

--- a/audio/src/web_ui/package.json
+++ b/audio/src/web_ui/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "framer-motion": "^11.0.0"
   }
 }

--- a/audio/src/web_ui/public/OSC Logo No Background.svg
+++ b/audio/src/web_ui/public/OSC Logo No Background.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="4" fill="none"/>
+  <line x1="50" y1="10" x2="50" y2="90" stroke="black" stroke-width="4"/>
+  <line x1="10" y1="50" x2="90" y2="50" stroke="black" stroke-width="4"/>
+</svg>

--- a/audio/src/web_ui/src/LogoTester.jsx
+++ b/audio/src/web_ui/src/LogoTester.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
+
+export default function LogoTester() {
+  const [svgContent, setSvgContent] = useState('');
+
+  useEffect(() => {
+    fetch('/dist/assets/OSC Logo No Background.svg')
+      .then(res => res.text())
+      .then(setSvgContent)
+      .catch(err => console.error('Failed to load SVG', err));
+  }, []);
+
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold mb-4">Logo Animation Tester</h1>
+      {svgContent ? (
+        <motion.div
+          className="inline-block"
+          initial={{ opacity: 0, scale: 0.5 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 1 }}
+          dangerouslySetInnerHTML={{ __html: svgContent }}
+        />
+      ) : (
+        <p>Loading SVG...</p>
+      )}
+    </div>
+  );
+}

--- a/audio/src/web_ui/src/logo.jsx
+++ b/audio/src/web_ui/src/logo.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import LogoTester from './LogoTester.jsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('logo-root')).render(
+  <React.StrictMode>
+    <LogoTester />
+  </React.StrictMode>
+);

--- a/audio/src/web_ui/vite.config.js
+++ b/audio/src/web_ui/vite.config.js
@@ -13,6 +13,12 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        logo: 'logo.html'
+      }
+    }
   },
   // Optimize dependencies to prevent vite from reloading the page on wasm changes
   optimizeDeps: {


### PR DESCRIPTION
## Summary
- add a Framer Motion animation tester page for the logo
- expose new page via Vite rollup input
- include placeholder OSC logo SVG
- keep build artifacts and lockfile out of git

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687414d5263c832d8a33d427c4a60550