### PR TITLE
Add voice offset columns

### DIFF
--- a/audio/src/main.py
+++ b/audio/src/main.py
@@ -632,7 +632,9 @@ class TrackEditorApp(QMainWindow):
         self.voices_tree.setColumnWidth(1, 100)
         self.voices_tree.setColumnWidth(2, 80)
         self.voices_tree.setColumnWidth(3, 80)
-        self.voices_tree.setColumnWidth(4, 150)
+        self.voices_tree.setColumnWidth(4, 80)
+        self.voices_tree.setColumnWidth(5, 80)
+        self.voices_tree.setColumnWidth(6, 150)
         self.voices_tree.header().setStretchLastSection(True)
         self.voices_tree.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.voices_tree.setEditTriggers(


### PR DESCRIPTION
## Summary
- expand `VoiceModel` with Init/Post Offset columns
- expose these columns in the main voices table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68788f70d458832d8e3c76a7636b090c