### PR TITLE
Add modulation skew control

### DIFF
--- a/audio/src/synth_functions/common.py
+++ b/audio/src/synth_functions/common.py
@@ -39,6 +39,34 @@ def sine_wave_varying(freq_array, t, sample_rate=44100):
     phase = initial_phase + 2 * np.pi * np.cumsum(freq_array * dt)
     return np.sin(phase)
 
+
+@numba.njit(fastmath=True, inline='always')
+def _frac(x):
+    """Return the fractional part of x."""
+    return x - np.floor(x)
+
+
+@numba.njit(fastmath=True, inline='always')
+def skewed_sine_phase(phase_fraction, skew):
+    """Sine wave with adjustable up/down symmetry.
+
+    ``phase_fraction`` should be in the range ``[0, 1)`` representing the
+    position within one cycle. ``skew`` ranges from -1.0 (long upswing) to
+    1.0 (short upswing). A value of 0.0 yields a standard sine shape.
+    """
+    frac = 0.5 + 0.5 * skew
+    if frac <= 0.0:
+        frac = 1e-9
+    if frac >= 1.0:
+        frac = 1.0 - 1e-9
+
+    if phase_fraction < frac:
+        local = phase_fraction / frac
+        return math.sin(math.pi * local)
+    else:
+        local = (phase_fraction - frac) / (1.0 - frac)
+        return math.sin(math.pi * (1.0 + local))
+
 def adsr_envelope(t, attack=0.01, decay=0.1, sustain_level=0.8, release=0.1):
     """
     Generate an ADSR envelope over t. Assumes that t starts at 0.


### PR DESCRIPTION
## Summary
- add `skewed_sine_phase` helper to shape LFO waveforms
- support `ampOscSkew*` and `freqOscSkew*` in binaural and isochronic synths
- update transition functions with skew parameters

## Testing
- `python -m py_compile audio/src/synth_functions/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6881a0ed1894832d8dbeb379f22ac2b7