### PR TITLE
Limit amplitude conversion to left/right fields

### DIFF
--- a/audio/src/ui/preferences_dialog.py
+++ b/audio/src/ui/preferences_dialog.py
@@ -162,7 +162,10 @@ class PreferencesDialog(QDialog):
         if parent and hasattr(parent, "track_data"):
             def convert_dict(d: dict):
                 for k, v in d.items():
-                    if isinstance(v, (int, float)) and "amp" in k.lower():
+                    if (
+                        isinstance(v, (int, float))
+                        and k.lower() in ("ampl", "ampr")
+                    ):
                         d[k] = amplitude_to_db(v)
 
             td = parent.track_data
@@ -185,7 +188,10 @@ class PreferencesDialog(QDialog):
             params = dv.get("params", {})
             if isinstance(params, dict):
                 for k, v in params.items():
-                    if isinstance(v, (int, float)) and "amp" in k.lower():
+                    if (
+                        isinstance(v, (int, float))
+                        and k.lower() in ("ampl", "ampr")
+                    ):
                         params[k] = amplitude_to_db(v)
 
     def get_preferences(self) -> Preferences:


### PR DESCRIPTION
## Summary
- Only convert `ampl` and `ampr` values when switching amplitudes to dB
- Prevent unintended conversion of unrelated parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688eedb3a964832d8e73504821a8e67f