### PR TITLE
Fix amplitude-to-dB conversion affecting non-amplitude params

### DIFF
--- a/audio/src/ui/preferences_dialog.py
+++ b/audio/src/ui/preferences_dialog.py
@@ -150,7 +150,7 @@ class PreferencesDialog(QDialog):
 
     def convert_amplitudes_to_db(self):
         """Convert current amplitude values in the project to dB."""
-        from utils.amp_utils import amplitude_to_db, MIN_DB
+        from utils.amp_utils import amplitude_to_db, is_amp_key
 
         if self._amp_mode != "dB":
             self._on_amp_mode_change("dB")
@@ -162,7 +162,7 @@ class PreferencesDialog(QDialog):
         if parent and hasattr(parent, "track_data"):
             def convert_dict(d: dict):
                 for k, v in d.items():
-                    if isinstance(v, (int, float)) and "amp" in k.lower():
+                    if isinstance(v, (int, float)) and is_amp_key(k):
                         d[k] = amplitude_to_db(v)
 
             td = parent.track_data
@@ -185,7 +185,7 @@ class PreferencesDialog(QDialog):
             params = dv.get("params", {})
             if isinstance(params, dict):
                 for k, v in params.items():
-                    if isinstance(v, (int, float)) and "amp" in k.lower():
+                    if isinstance(v, (int, float)) and is_amp_key(k):
                         params[k] = amplitude_to_db(v)
 
     def get_preferences(self) -> Preferences:

--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -33,6 +33,7 @@ from utils.voice_file import (
     save_voice_preset,
     VOICE_FILE_EXTENSION,
 )
+from utils.amp_utils import amplitude_to_db, db_to_amplitude, is_amp_key
 
 # Constants from your original dialog structure for envelopes
 ENVELOPE_TYPE_NONE = "None"
@@ -365,11 +366,13 @@ class VoiceEditorDialog(QDialog): # Standard class name
             default_value = default_params_ordered[name]
             current_value = params_to_display.get(name, default_value)
             display_current = current_value
-            if isinstance(current_value, (int, float)) and getattr(self.app, "prefs", None) and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB":
-                nlow = name.lower()
-                if any(s in nlow for s in ["amp", "gain", "level"]):
-                    from utils.amp_utils import amplitude_to_db
-                    display_current = amplitude_to_db(float(current_value))
+            if (
+                isinstance(current_value, (int, float))
+                and getattr(self.app, "prefs", None)
+                and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB"
+                and is_amp_key(name)
+            ):
+                display_current = amplitude_to_db(float(current_value))
 
             prefix, base_after = self._split_name_prefix(name)
 
@@ -381,11 +384,13 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     end_current_value = params_to_display.get(end_name, end_default_value)
                     display_start = display_current
                     display_end = end_current_value
-                    if isinstance(end_current_value, (int, float)) and getattr(self.app, "prefs", None) and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB":
-                        nlow = end_name.lower()
-                        if any(s in nlow for s in ["amp", "gain", "level"]):
-                            from utils.amp_utils import amplitude_to_db
-                            display_end = amplitude_to_db(float(end_current_value))
+                    if (
+                        isinstance(end_current_value, (int, float))
+                        and getattr(self.app, "prefs", None)
+                        and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB"
+                        and is_amp_key(end_name)
+                    ):
+                        display_end = amplitude_to_db(float(end_current_value))
 
                     frame = QWidget()
                     row_layout = QGridLayout(frame)
@@ -459,16 +464,20 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     right_cur = params_to_display.get(right_name, right_def)
                     disp_left = left_cur
                     disp_right = right_cur
-                    if isinstance(left_cur, (int, float)) and getattr(self.app, "prefs", None) and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB":
-                        nlow = left_name.lower()
-                        if any(s in nlow for s in ["amp", "gain", "level"]):
-                            from utils.amp_utils import amplitude_to_db
-                            disp_left = amplitude_to_db(float(left_cur))
-                    if isinstance(right_cur, (int, float)) and getattr(self.app, "prefs", None) and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB":
-                        nlow = right_name.lower()
-                        if any(s in nlow for s in ["amp", "gain", "level"]):
-                            from utils.amp_utils import amplitude_to_db
-                            disp_right = amplitude_to_db(float(right_cur))
+                    if (
+                        isinstance(left_cur, (int, float))
+                        and getattr(self.app, "prefs", None)
+                        and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB"
+                        and is_amp_key(left_name)
+                    ):
+                        disp_left = amplitude_to_db(float(left_cur))
+                    if (
+                        isinstance(right_cur, (int, float))
+                        and getattr(self.app, "prefs", None)
+                        and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB"
+                        and is_amp_key(right_name)
+                    ):
+                        disp_right = amplitude_to_db(float(right_cur))
 
                     frame = QWidget()
                     row_layout = QGridLayout(frame)
@@ -555,11 +564,13 @@ class VoiceEditorDialog(QDialog): # Standard class name
                 end_current_value = params_to_display.get(end_name, end_default_value)
                 display_start = display_current
                 display_end = end_current_value
-                if isinstance(end_current_value, (int, float)) and getattr(self.app, "prefs", None) and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB":
-                    nlow = end_name.lower()
-                    if any(s in nlow for s in ["amp", "gain", "level"]):
-                        from utils.amp_utils import amplitude_to_db
-                        display_end = amplitude_to_db(float(end_current_value))
+                if (
+                    isinstance(end_current_value, (int, float))
+                    and getattr(self.app, "prefs", None)
+                    and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB"
+                    and is_amp_key(end_name)
+                ):
+                    display_end = amplitude_to_db(float(end_current_value))
 
                 current_validator = None # Create a new validator instance for each pair or reuse type
                 if param_type_hint == 'int':
@@ -712,8 +723,12 @@ class VoiceEditorDialog(QDialog): # Standard class name
                 entry = QLineEdit()
                 entry.setValidator(copy.deepcopy(validator_type))
                 val = current_env_params.get(param_name, default_val)
-                if isinstance(val, (int, float)) and getattr(self.app, "prefs", None) and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB" and "amp" in param_name:
-                    from utils.amp_utils import amplitude_to_db
+                if (
+                    isinstance(val, (int, float))
+                    and getattr(self.app, "prefs", None)
+                    and getattr(self.app.prefs, "amplitude_display_mode", "absolute") == "dB"
+                    and is_amp_key(param_name)
+                ):
                     val = amplitude_to_db(float(val))
                 entry.setText(str(val))
 
@@ -905,11 +920,12 @@ class VoiceEditorDialog(QDialog): # Standard class name
                 continue
 
             display_val = raw_val
-            if amplitude_in_db and isinstance(raw_val, (int, float)):
-                nlow = name.lower()
-                if any(s in nlow for s in ["amp", "gain", "level"]):
-                    from ..utils.amp_utils import amplitude_to_db
-                    display_val = amplitude_to_db(float(raw_val))
+            if (
+                amplitude_in_db
+                and isinstance(raw_val, (int, float))
+                and is_amp_key(name)
+            ):
+                display_val = amplitude_to_db(float(raw_val))
 
             if isinstance(widget, QLineEdit):
                 widget.setText(str(display_val))
@@ -1109,11 +1125,13 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     value = None
             
             if value is not None:
-                if param_type == 'float' and getattr(self.app, 'prefs', None) and getattr(self.app.prefs, 'amplitude_display_mode', 'absolute') == 'dB':
-                    nlow = name.lower()
-                    if any(s in nlow for s in ['amp', 'gain', 'level']):
-                        from ..utils.amp_utils import db_to_amplitude
-                        value = db_to_amplitude(float(value))
+                if (
+                    param_type == 'float'
+                    and getattr(self.app, 'prefs', None)
+                    and getattr(self.app.prefs, 'amplitude_display_mode', 'absolute') == 'dB'
+                    and is_amp_key(name)
+                ):
+                    value = db_to_amplitude(float(value))
                 synth_params[name] = value
         
         # Collect envelope data
@@ -1129,11 +1147,12 @@ class VoiceEditorDialog(QDialog): # Standard class name
                         try:
                             if param_type == 'float':
                                 val = float(value_str.replace(',', '.'))
-                                if getattr(self.app, 'prefs', None) and getattr(self.app.prefs, 'amplitude_display_mode', 'absolute') == 'dB':
-                                    nlow = name.lower()
-                                    if any(s in nlow for s in ['amp', 'gain', 'level']):
-                                        from ..utils.amp_utils import db_to_amplitude
-                                        val = db_to_amplitude(val)
+                                if (
+                                    getattr(self.app, 'prefs', None)
+                                    and getattr(self.app.prefs, 'amplitude_display_mode', 'absolute') == 'dB'
+                                    and is_amp_key(name)
+                                ):
+                                    val = db_to_amplitude(val)
                                 env_params[name] = val
                             elif param_type == 'int': 
                                 env_params[name] = int(value_str)

--- a/audio/src/utils/amp_utils.py
+++ b/audio/src/utils/amp_utils.py
@@ -1,13 +1,16 @@
 import math
+import re
 
 MIN_DB = -60.0
+_AMP_PARAM_RE = re.compile(r'(?:^|_)(?:amp|amplitude|gain|level)(?:$|_)')
 
 
 def amplitude_to_db(amplitude: float) -> float:
-    """Convert linear amplitude (0.0-1.0+) to dBFS."""
+    """Convert linear amplitude (0.0-1.0+) to dBFS, clamped to MIN_DB."""
     if amplitude <= 0:
         return MIN_DB
-    return 20.0 * math.log10(amplitude)
+    db = 20.0 * math.log10(amplitude)
+    return db if db > MIN_DB else MIN_DB
 
 
 def db_to_amplitude(db: float) -> float:
@@ -15,3 +18,8 @@ def db_to_amplitude(db: float) -> float:
     if db <= MIN_DB:
         return 0.0
     return 10 ** (db / 20.0)
+
+
+def is_amp_key(name: str) -> bool:
+    """Return True if the parameter name refers to an amplitude value."""
+    return bool(_AMP_PARAM_RE.search(name.lower()))


### PR DESCRIPTION
## Summary
- Clamp amplitude-to-dB calculations at MIN_DB and add regex-based detection of amplitude parameter names
- Convert amplitudes to dB only for true amplitude keys in preferences dialog
- Use the same amplitude key detection in voice editor to avoid converting non-amplitude parameters

## Testing
- `python -m py_compile audio/src/utils/amp_utils.py audio/src/ui/preferences_dialog.py audio/src/ui/voice_editor_dialog.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eed3f3be8832dbaaf8e2be2a4755c