### PR TITLE
Remove redundant amp parameter from isochronic tone voice

### DIFF
--- a/audio/src/README.md
+++ b/audio/src/README.md
@@ -132,7 +132,7 @@ Additional parameters:
 | `pan` | 0 | Extra stereo pan applied after modulation |
 
 The `_transition` variant accepts `start` and `end` forms of each parameter
-(`startAmp`/`endAmp`, `startBaseFreq`/`endBaseFreq`, etc.) to smoothly move
+(`startAmpL`/`endAmpL`, `startAmpR`/`endAmpR`, `startBaseFreq`/`endBaseFreq`, etc.) to smoothly move
 between settings over the step.
 
 ### monaural_beat_stereo_amps

--- a/audio/src/synth_functions/isochronic_tone.py
+++ b/audio/src/synth_functions/isochronic_tone.py
@@ -117,13 +117,12 @@ def _isochronic_tone_core(
 def isochronic_tone(duration, sample_rate=44100, **params):
     """Generate an isochronic tone with extended modulation options."""
 
-    # Legacy amplitude/pan parameters
-    base_amp = float(params.get('amp', 0.5))
+    # Legacy pan parameter
     pan = float(params.get('pan', 0.0))
 
     # Extended parameters matching ``binaural_beat`` (glitch parameters omitted)
-    ampL = float(params.get('ampL', base_amp))
-    ampR = float(params.get('ampR', base_amp))
+    ampL = float(params.get('ampL', 0.5))
+    ampR = float(params.get('ampR', 0.5))
     baseFreq = float(params.get('baseFreq', 200.0))
     beatFreq = float(params.get('beatFreq', 4.0))  # Pulse rate
     force_mono = bool(params.get('forceMono', False))
@@ -195,10 +194,9 @@ def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, 
 
     """Transitioning version of :func:`isochronic_tone`."""
 
-    base_amp = float(params.get('amp', 0.5))
-    startAmpL = float(params.get('startAmpL', params.get('ampL', base_amp)))
+    startAmpL = float(params.get('startAmpL', params.get('ampL', 0.5)))
     endAmpL = float(params.get('endAmpL', startAmpL))
-    startAmpR = float(params.get('startAmpR', params.get('ampR', base_amp)))
+    startAmpR = float(params.get('startAmpR', params.get('ampR', 0.5)))
     endAmpR = float(params.get('endAmpR', startAmpR))
 
     startBaseFreq = float(params.get('startBaseFreq', 200.0))

--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -1425,7 +1425,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
             },
             "isochronic_tone": {
                 "standard": [
-                    ('amp', 0.5), ('ampL', 0.5), ('ampR', 0.5),
+                    ('ampL', 0.5), ('ampR', 0.5),
                     ('baseFreq', 200.0), ('beatFreq', 4.0),
                     ('forceMono', False), ('startPhaseL', 0.0), ('startPhaseR', 0.0),
                     ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0),


### PR DESCRIPTION
## Summary
- simplify `isochronic_tone` by relying solely on channel amplitudes `ampL` and `ampR`
- drop `amp` from isochronic tone editor defaults and update transition docs

## Testing
- `pytest`
- `python -m py_compile audio/src/synth_functions/isochronic_tone.py audio/src/ui/voice_editor_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_689bbbb26a64832da59f082c928072c3