### PR TITLE
Add harmonic suppression option for isochronic tone voice

### DIFF
--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -1436,7 +1436,8 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('freqOscPhaseOffsetL', 0.0), ('freqOscPhaseOffsetR', 0.0),
                     ('ampOscPhaseOffsetL', 0.0), ('ampOscPhaseOffsetR', 0.0),
                     ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0),
-                    ('rampPercent', 0.2), ('gapPercent', 0.15), ('pan', 0.0)
+                    ('rampPercent', 0.2), ('gapPercent', 0.15),
+                    ('harmonicSuppression', False), ('pan', 0.0)
                 ],
                 "transition": [
                     ('startAmpL', 0.5), ('endAmpL', 0.5),
@@ -1464,6 +1465,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0),
                     ('startRampPercent', 0.2), ('endRampPercent', 0.2),
                     ('startGapPercent', 0.15), ('endGapPercent', 0.15),
+                    ('startHarmonicSuppression', False), ('endHarmonicSuppression', False),
                     ('startPan', 0.0), ('endPan', 0.0),
                     ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]


### PR DESCRIPTION
## Summary
- add optional harmonic suppression filter to isochronic tone generators
- expose harmonic suppression parameter in GUI parameter dictionary for standard and transition modes

## Testing
- `python -m py_compile audio/src/synth_functions/isochronic_tone.py audio/src/ui/voice_editor_dialog.py`
- `python - <<'PY'
import sys, numpy as np
sys.path.append('audio/src')
from synth_functions.isochronic_tone import isochronic_tone
sig = isochronic_tone(0.1, sample_rate=44100, baseFreq=200, beatFreq=4, harmonicSuppression=True)
print(sig.shape, float(np.max(sig)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_689bbcef30a8832db6284e9dd479464e