### PR TITLE
Add ITD-only spatial decoder option

### DIFF
--- a/audio/src/synth_functions/binaural_beat.py
+++ b/audio/src/synth_functions/binaural_beat.py
@@ -143,6 +143,7 @@ def binaural_beat(duration, sample_rate=44100, **params):
             hf_roll_db_per_m=float(params.get("spatialHfRollDbPerM", 0.0)),
             dz_theta_ms=float(params.get("spatialDezipperThetaMs", 25.0)),
             dz_dist_ms=float(params.get("spatialDezipperDistMs", 60.0)),
+            decoder=0 if str(params.get("spatialDecoder", "itd_head")).lower() != "foa_cardioid" else 1,
         )
 
     return audio
@@ -436,6 +437,7 @@ def binaural_beat_transition(duration, sample_rate=44100, initial_offset=0.0, po
             hf_roll_db_per_m=float(params.get("spatialHfRollDbPerM", 0.0)),
             dz_theta_ms=float(params.get("spatialDezipperThetaMs", 25.0)),
             dz_dist_ms=float(params.get("spatialDezipperDistMs", 60.0)),
+            decoder=0 if str(params.get("spatialDecoder", "itd_head")).lower() != "foa_cardioid" else 1,
         )
 
     return audio

--- a/audio/src/synth_functions/isochronic_tone.py
+++ b/audio/src/synth_functions/isochronic_tone.py
@@ -227,6 +227,7 @@ def isochronic_tone(duration, sample_rate=44100, **params):
             hf_roll_db_per_m=float(params.get("spatialHfRollDbPerM", 0.0)),
             dz_theta_ms=float(params.get("spatialDezipperThetaMs", 25.0)),
             dz_dist_ms=float(params.get("spatialDezipperDistMs", 60.0)),
+            decoder=0 if str(params.get("spatialDecoder", "itd_head")).lower() != "foa_cardioid" else 1,
         )
 
     return audio
@@ -467,6 +468,7 @@ def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, 
             hf_roll_db_per_m=float(params.get("spatialHfRollDbPerM", 0.0)),
             dz_theta_ms=float(params.get("spatialDezipperThetaMs", 25.0)),
             dz_dist_ms=float(params.get("spatialDezipperDistMs", 60.0)),
+            decoder=0 if str(params.get("spatialDecoder", "itd_head")).lower() != "foa_cardioid" else 1,
         )
 
     # Note: Volume envelope (like ADSR/Linen) is applied *within* generate_voice_audio if specified there.

--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -127,6 +127,7 @@ SPATIAL_TOOLTIPS = {
     'spatialItdScale': 'Scale factor for interaural time differences.',
     'spatialIldMaxDb': 'Maximum interaural level difference in dB.',
     'spatialIldXoverHz': 'Frequency where ILD shelf begins (Hz).',
+    'spatialDecoder': 'Spatial decoder: "itd_head" (time-delay) or "foa_cardioid" (legacy).',
     'spatialRefDistanceM': 'Reference distance for distance attenuation (meters).',
     'spatialRolloff': 'Distance rolloff exponent.',
     'spatialHfRollDbPerM': 'High-frequency rolloff per meter (dB).',


### PR DESCRIPTION
## Summary
- Add decoder switch supporting `itd_head` (default) or legacy `foa_cardioid`
- Implement ITD-only head model to eliminate FOA cardioid swirl
- Expose decoder choice in binaural/isochronic voices and UI tooltips

## Testing
- `python -m py_compile audio/src/synth_functions/spatial_ambi2d.py audio/src/synth_functions/binaural_beat.py audio/src/synth_functions/isochronic_tone.py audio/src/ui/voice_editor_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7f05e76d0832d8e17d385a96585cd