### PR TITLE
Expose period for rotating arc trajectory

### DIFF
--- a/audio/src/synth_functions/spatial_ambi2d.py
+++ b/audio/src/synth_functions/spatial_ambi2d.py
@@ -313,7 +313,8 @@ def generate_azimuth_trajectory(
                     (ignored if using speed); for rotating_arc: arc width in degrees
       - center_deg: for oscillate only (center of arc)
       - speed_deg_per_s: rotate speed (deg/s), sign sets direction
-      - period_s: for oscillate (alt to speed)
+      - period_s: for oscillate (alt to speed); for rotating_arc: time for beat
+                   to sweep the arc start→end→start
       - rotate_freq_hz: for rotating_arc, rotation frequency of the entire arc
                         (Hz, sign sets direction)
       - easing: "linear" | "sine" (optional)
@@ -357,7 +358,9 @@ def generate_azimuth_trajectory(
             th = start + sp * t
         elif mode == "rotating_arc":
             # Sweep across arc while rotating the arc around the listener
-            phase = 2 * np.pi * (t / sec if sec > 0 else 0.0)
+            if period is None or period <= 0:
+                period = sec
+            phase = 2 * np.pi * (t / period)
             arc_progress = (1 - np.cos(phase)) / 2.0  # 0 -> 1 -> 0
             rotation = 360.0 * rotate_freq * t
             arc_start = start + rotation

--- a/audio/src/ui/spatial_trajectory_dialog.py
+++ b/audio/src/ui/spatial_trajectory_dialog.py
@@ -122,7 +122,7 @@ class SpatialTrajectorySegmentDialog(QDialog):
         set_vis(is_rotate, self.speed_label, self.speed_spin)
         set_vis(is_oscillate, self.center_label, self.center_spin)
         set_vis(is_rotating_arc or is_oscillate, self.extent_label, self.extent_spin)
-        set_vis(is_oscillate, self.period_label, self.period_spin)
+        set_vis(is_rotating_arc or is_oscillate, self.period_label, self.period_spin)
         set_vis(is_rotating_arc, self.rotate_freq_label, self.rotate_freq_spin)
 
     def get_segment(self) -> dict:
@@ -134,6 +134,7 @@ class SpatialTrajectorySegmentDialog(QDialog):
             seg["start_deg"] = float(self.start_spin.value())
             seg["extent_deg"] = float(self.extent_spin.value())
             seg["rotate_freq_hz"] = float(self.rotate_freq_spin.value())
+            seg["period_s"] = float(self.period_spin.value())
         else:
             seg["center_deg"] = float(self.center_spin.value())
             seg["extent_deg"] = float(self.extent_spin.value())
@@ -193,7 +194,7 @@ class SpatialTrajectoryDialog(QDialog):
         elif seg.get("mode") == "rotating_arc":
             desc = (
                 f"rotating_arc start={seg.get('start_deg', 0)} extent={seg.get('extent_deg', 0)}"
-                f" rot_freq={seg.get('rotate_freq_hz', 0)}"
+                f" rot_freq={seg.get('rotate_freq_hz', 0)} period={seg.get('period_s', 0)}"
             )
         else:
             desc = (


### PR DESCRIPTION
## Summary
- allow rotating arc spatial trajectory to specify sweep period
- show and save period control in spatial trajectory dialog

## Testing
- `python -m py_compile audio/src/synth_functions/spatial_ambi2d.py audio/src/ui/spatial_trajectory_dialog.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f45e8f04832daab7ca03916b8602