### PR TITLE
Fix flanger and spatial toggle interference

### DIFF
--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -922,16 +922,16 @@ class VoiceEditorDialog(QDialog): # Standard class name
         if flange_enable_data:
             enable_widget = flange_enable_data['widget']
 
-            other_widgets = []
+            flange_widgets = []
             for n, data in self.param_widgets.items():
                 if 'flange' in n.lower() and n != 'flangeEnable':
                     row_widget = data['widget'].parentWidget()
-                    if row_widget and row_widget not in other_widgets:
-                        other_widgets.append(row_widget)
+                    if row_widget and row_widget not in flange_widgets:
+                        flange_widgets.append(row_widget)
 
             def _set_flange_enabled(state):
                 visible = bool(state)
-                for w in other_widgets:
+                for w in flange_widgets:
                     w.setVisible(visible)
                     w.setEnabled(visible)
 
@@ -948,16 +948,16 @@ class VoiceEditorDialog(QDialog): # Standard class name
         if spatial_enable_data:
             enable_widget = spatial_enable_data['widget']
 
-            other_widgets = []
+            spatial_widgets = []
             for n, data in self.param_widgets.items():
                 if n.lower().startswith('spatial') and n != 'spatialEnable':
                     row_widget = data['widget'].parentWidget()
-                    if row_widget and row_widget not in other_widgets:
-                        other_widgets.append(row_widget)
+                    if row_widget and row_widget not in spatial_widgets:
+                        spatial_widgets.append(row_widget)
 
             def _set_spatial_enabled(state):
                 visible = bool(state)
-                for w in other_widgets:
+                for w in spatial_widgets:
                     w.setVisible(visible)
                     w.setEnabled(visible)
 


### PR DESCRIPTION
## Summary
- Ensure flanger checkbox only controls flanger parameters
- Ensure spatial checkbox only controls spatial parameters

## Testing
- `python -m py_compile audio/src/ui/voice_editor_dialog.py`
- `python - <<'PY'
import os,sys
sys.path.append('audio/src')
os.environ['QT_QPA_PLATFORM']='offscreen'
from ui.voice_editor_dialog import VoiceEditorDialog
from PyQt5.QtWidgets import QApplication
class DummyPrefs: amplitude_display_mode='absolute'
class DummyApp:
    prefs=DummyPrefs(); track_data={'steps': []}
    def get_selected_step_index(self): return None
    def get_selected_voice_index(self): return None
app=QApplication([])
dlg=VoiceEditorDialog(None, DummyApp(), 0)
flange_widget=dlg.param_widgets['flangeEnable']['widget']
spatial_widget=dlg.param_widgets['spatialEnable']['widget']
flange_sample=next(data['widget'] for n,data in dlg.param_widgets.items() if 'flange' in n.lower() and n!='flangeEnable')
spatial_sample=next(data['widget'] for n,data in dlg.param_widgets.items() if n.lower().startswith('spatial') and n!='spatialEnable')
print('initial enabled', flange_sample.parentWidget().isEnabled(), spatial_sample.parentWidget().isEnabled())
flange_widget.setChecked(True); print('after flange enable', flange_sample.parentWidget().isEnabled(), spatial_sample.parentWidget().isEnabled())
flange_widget.setChecked(False); print('after flange disable', flange_sample.parentWidget().isEnabled(), spatial_sample.parentWidget().isEnabled())
spatial_widget.setChecked(True); print('after spatial enable', flange_sample.parentWidget().isEnabled(), spatial_sample.parentWidget().isEnabled())
spatial_widget.setChecked(False); print('after spatial disable', flange_sample.parentWidget().isEnabled(), spatial_sample.parentWidget().isEnabled())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8108b125c832dba5a337e0f6f56fc