### PR TITLE
Remove non-spatial stability parameters from audio UI

### DIFF
--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -72,24 +72,19 @@ PARAM_TOOLTIPS = {
         'ampOscDepthL': 'Depth of amplitude modulation applied to the left channel.',
         'ampOscFreqL': 'Frequency of amplitude modulation for the left channel in Hz.',
         'ampOscPhaseOffsetL': 'Phase offset for left channel amplitude modulation.',
-        'ampOscStabilityL': 'Stability of amplitude modulation for the left channel.',
         'ampOscDepthR': 'Depth of amplitude modulation applied to the right channel.',
         'ampOscFreqR': 'Frequency of amplitude modulation for the right channel in Hz.',
         'ampOscPhaseOffsetR': 'Phase offset for right channel amplitude modulation.',
-        'ampOscStabilityR': 'Stability of amplitude modulation for the right channel.',
         'freqOscRangeL': 'Range of frequency modulation for the left channel in Hz.',
         'freqOscFreqL': 'Frequency of frequency modulation for the left channel in Hz.',
         'freqOscSkewL': 'Skew factor for left channel frequency modulation waveform.',
         'freqOscPhaseOffsetL': 'Phase offset for left channel frequency modulation.',
-        'freqOscStabilityL': 'Stability of frequency modulation for the left channel.',
         'freqOscRangeR': 'Range of frequency modulation for the right channel in Hz.',
         'freqOscFreqR': 'Frequency of frequency modulation for the right channel in Hz.',
         'freqOscSkewR': 'Skew factor for right channel frequency modulation waveform.',
         'freqOscPhaseOffsetR': 'Phase offset for right channel frequency modulation.',
-        'freqOscStabilityR': 'Stability of frequency modulation for the right channel.',
         'phaseOscFreq': 'Frequency of phase modulation applied to both channels.',
         'phaseOscRange': 'Range of phase modulation in radians.',
-        'phaseOscStability': 'Stability of phase modulation applied to both channels.',
     }
 }
 
@@ -1704,22 +1699,13 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('ampL', 0.5), ('ampR', 0.5),
                     ('baseFreq', 200.0), ('beatFreq', 4.0),
                     ('startPhaseL', 0.0), ('startPhaseR', 0.0),
-                    ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0), ('ampOscPhaseOffsetL', 0.0), ('ampOscStabilityL', 0.0),
-                    ('ampOscDepthR', 0.0), ('ampOscFreqR', 0.0), ('ampOscPhaseOffsetR', 0.0), ('ampOscStabilityR', 0.0),
-                    ('freqOscRangeL', 0.0), ('freqOscFreqL', 0.0), ('freqOscSkewL', 0.0), ('freqOscPhaseOffsetL', 0.0), ('freqOscStabilityL', 0.0),
-                    ('freqOscRangeR', 0.0), ('freqOscFreqR', 0.0), ('freqOscSkewR', 0.0), ('freqOscPhaseOffsetR', 0.0), ('freqOscStabilityR', 0.0),
-                    ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0), ('phaseOscStability', 0.0)
+                    ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0), ('ampOscPhaseOffsetL', 0.0), ('ampOscDepthR', 0.0), ('ampOscFreqR', 0.0), ('ampOscPhaseOffsetR', 0.0), ('freqOscRangeL', 0.0), ('freqOscFreqL', 0.0), ('freqOscSkewL', 0.0), ('freqOscPhaseOffsetL', 0.0), ('freqOscRangeR', 0.0), ('freqOscFreqR', 0.0), ('freqOscSkewR', 0.0), ('freqOscPhaseOffsetR', 0.0), ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0)
                 ],
                 "transition": [
                     ('startAmpL', 0.5), ('endAmpL', 0.5), ('startAmpR', 0.5), ('endAmpR', 0.5),
                     ('startBaseFreq', 200.0), ('endBaseFreq', 200.0), ('startBeatFreq', 4.0), ('endBeatFreq', 4.0),
                     ('startStartPhaseL', 0.0), ('endStartPhaseL', 0.0), ('startStartPhaseR', 0.0), ('endStartPhaseR', 0.0),
-                    ('startAmpOscDepthL', 0.0), ('endAmpOscDepthL', 0.0), ('startAmpOscFreqL', 0.0), ('endAmpOscFreqL', 0.0), ('startAmpOscPhaseOffsetL', 0.0), ('endAmpOscPhaseOffsetL', 0.0), ('startAmpOscStabilityL', 0.0), ('endAmpOscStabilityL', 0.0),
-                    ('startAmpOscDepthR', 0.0), ('endAmpOscDepthR', 0.0), ('startAmpOscFreqR', 0.0), ('endAmpOscFreqR', 0.0), ('startAmpOscPhaseOffsetR', 0.0), ('endAmpOscPhaseOffsetR', 0.0), ('startAmpOscStabilityR', 0.0), ('endAmpOscStabilityR', 0.0),
-                    ('startFreqOscRangeL', 0.0), ('endFreqOscRangeL', 0.0), ('startFreqOscFreqL', 0.0), ('endFreqOscFreqL', 0.0), ('startFreqOscSkewL', 0.0), ('endFreqOscSkewL', 0.0), ('startFreqOscPhaseOffsetL', 0.0), ('endFreqOscPhaseOffsetL', 0.0), ('startFreqOscStabilityL', 0.0), ('endFreqOscStabilityL', 0.0),
-                    ('startFreqOscRangeR', 0.0), ('endFreqOscRangeR', 0.0), ('startFreqOscFreqR', 0.0), ('endFreqOscFreqR', 0.0), ('startFreqOscSkewR', 0.0), ('endFreqOscSkewR', 0.0), ('startFreqOscPhaseOffsetR', 0.0), ('endFreqOscPhaseOffsetR', 0.0), ('startFreqOscStabilityR', 0.0), ('endFreqOscStabilityR', 0.0),
-                    ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0), ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0), ('startPhaseOscStability', 0.0), ('endPhaseOscStability', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('startAmpOscDepthL', 0.0), ('endAmpOscDepthL', 0.0), ('startAmpOscFreqL', 0.0), ('endAmpOscFreqL', 0.0), ('startAmpOscPhaseOffsetL', 0.0), ('endAmpOscPhaseOffsetL', 0.0), ('startAmpOscDepthR', 0.0), ('endAmpOscDepthR', 0.0), ('startAmpOscFreqR', 0.0), ('endAmpOscFreqR', 0.0), ('startAmpOscPhaseOffsetR', 0.0), ('endAmpOscPhaseOffsetR', 0.0), ('startFreqOscRangeL', 0.0), ('endFreqOscRangeL', 0.0), ('startFreqOscFreqL', 0.0), ('endFreqOscFreqL', 0.0), ('startFreqOscSkewL', 0.0), ('endFreqOscSkewL', 0.0), ('startFreqOscPhaseOffsetL', 0.0), ('endFreqOscPhaseOffsetL', 0.0), ('startFreqOscRangeR', 0.0), ('endFreqOscRangeR', 0.0), ('startFreqOscFreqR', 0.0), ('endFreqOscFreqR', 0.0), ('startFreqOscSkewR', 0.0), ('endFreqOscSkewR', 0.0), ('startFreqOscPhaseOffsetR', 0.0), ('endFreqOscPhaseOffsetR', 0.0), ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0), ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0), ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "monaural_beat_stereo_amps": { # This is an example, ensure it's correct
@@ -1729,7 +1715,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('baseFreq', 200.0), ('beatFreq', 4.0),
                     ('startPhaseL', 0.0), ('startPhaseR', 0.0),
                     ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0),
-                    ('ampOscDepth', 0.0), ('ampOscFreq', 0.0), ('ampOscPhaseOffset', 0.0), ('ampOscStability', 0.0)
+                    ('ampOscDepth', 0.0), ('ampOscFreq', 0.0), ('ampOscPhaseOffset', 0.0)
                 ],
                 "transition": [
                     ('start_amp_lower_L', 0.5), ('end_amp_lower_L', 0.5),
@@ -1744,21 +1730,18 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0),
                     ('startAmpOscDepth', 0.0), ('endAmpOscDepth', 0.0),
                     ('startAmpOscFreq', 0.0), ('endAmpOscFreq', 0.0),
-                    ('startAmpOscPhaseOffset', 0.0), ('endAmpOscPhaseOffset', 0.0), ('startAmpOscStability', 0.0), ('endAmpOscStability', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('startAmpOscPhaseOffset', 0.0), ('endAmpOscPhaseOffset', 0.0), ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "spatial_angle_modulation_monaural_beat": {
                 "standard": [ 
-                    ('sam_ampOscDepth', 0.0), ('sam_ampOscFreq', 0.0), ('sam_ampOscPhaseOffset', 0.0), ('sam_ampOscStability', 0.0),
-                    ('amp_lower_L', 0.5), ('amp_upper_L', 0.5),
+                    ('sam_ampOscDepth', 0.0), ('sam_ampOscFreq', 0.0), ('sam_ampOscPhaseOffset', 0.0), ('amp_lower_L', 0.5), ('amp_upper_L', 0.5),
                     ('amp_lower_R', 0.5), ('amp_upper_R', 0.5),
                     ('baseFreq', 200.0), ('beatFreq', 4.0),
                     ('startPhaseL', 0.0), ('startPhaseR', 0.0),
                     ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0),
                     ('monaural_ampOscDepth', 0.0), ('monaural_ampOscFreq', 0.0),
-                    ('monaural_ampOscPhaseOffset', 0.0), ('monaural_ampOscStability', 0.0),
-                    ('spatialBeatFreq', 4.0), ('spatialPhaseOffset', 0.0),
+                    ('monaural_ampOscPhaseOffset', 0.0), ('spatialBeatFreq', 4.0), ('spatialPhaseOffset', 0.0),
                     ('amp', 0.7), ('pathRadius', 1.0),
                     ('frame_dur_ms', 46.4), ('overlap_factor', 8)
                 ],
@@ -1775,11 +1758,9 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startPhaseOscRange_monaural', 0.0), ('endPhaseOscRange_monaural', 0.0),
                     ('startAmpOscDepth_monaural', 0.0), ('endAmpOscDepth_monaural', 0.0),
                     ('startAmpOscFreq_monaural', 0.0), ('endAmpOscFreq_monaural', 0.0),
-                    ('startAmpOscPhaseOffset_monaural', 0.0), ('endAmpOscPhaseOffset_monaural', 0.0), ('startAmpOscStability_monaural', 0.0), ('endAmpOscStability_monaural', 0.0),
-                    ('start_sam_ampOscDepth', 0.0), ('end_sam_ampOscDepth', 0.0),
+                    ('startAmpOscPhaseOffset_monaural', 0.0), ('endAmpOscPhaseOffset_monaural', 0.0), ('start_sam_ampOscDepth', 0.0), ('end_sam_ampOscDepth', 0.0),
                     ('start_sam_ampOscFreq', 0.0), ('end_sam_ampOscFreq', 0.0),
-                    ('start_sam_ampOscPhaseOffset', 0.0), ('end_sam_ampOscPhaseOffset', 0.0), ('start_sam_ampOscStability', 0.0), ('end_sam_ampOscStability', 0.0),
-                    ('startSpatialBeatFreq', 4.0), ('endSpatialBeatFreq', 4.0),
+                    ('start_sam_ampOscPhaseOffset', 0.0), ('end_sam_ampOscPhaseOffset', 0.0), ('startSpatialBeatFreq', 4.0), ('endSpatialBeatFreq', 4.0),
                     ('startSpatialPhaseOffset', 0.0), ('endSpatialPhaseOffset', 0.0),
                     ('startPathRadius', 1.0), ('endPathRadius', 1.0),
                     ('startAmp', 0.7), ('endAmp', 0.7),
@@ -1792,12 +1773,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('ampL', 0.5), ('ampR', 0.5),
                     ('baseFreq', 200.0), ('beatFreq', 4.0), ('forceMono', False),
                     ('startPhaseL', 0.0), ('startPhaseR', 0.0),
-                    ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0), ('ampOscPhaseOffsetL', 0.0), ('ampOscStabilityL', 0.0),
-                    ('ampOscDepthR', 0.0), ('ampOscFreqR', 0.0), ('ampOscPhaseOffsetR', 0.0), ('ampOscStabilityR', 0.0),
-                    ('freqOscRangeL', 0.0), ('freqOscFreqL', 0.0), ('freqOscSkewL', 0.0), ('freqOscPhaseOffsetL', 0.0), ('freqOscStabilityL', 0.0),
-                    ('freqOscRangeR', 0.0), ('freqOscFreqR', 0.0), ('freqOscSkewR', 0.0), ('freqOscPhaseOffsetR', 0.0), ('freqOscStabilityR', 0.0),
-                    ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0), ('phaseOscStability', 0.0),
-                    ('rampPercent', 0.2), ('gapPercent', 0.15),
+                    ('ampOscDepthL', 0.0), ('ampOscFreqL', 0.0), ('ampOscPhaseOffsetL', 0.0), ('ampOscDepthR', 0.0), ('ampOscFreqR', 0.0), ('ampOscPhaseOffsetR', 0.0), ('freqOscRangeL', 0.0), ('freqOscFreqL', 0.0), ('freqOscSkewL', 0.0), ('freqOscPhaseOffsetL', 0.0), ('freqOscRangeR', 0.0), ('freqOscFreqR', 0.0), ('freqOscSkewR', 0.0), ('freqOscPhaseOffsetR', 0.0), ('phaseOscFreq', 0.0), ('phaseOscRange', 0.0), ('rampPercent', 0.2), ('gapPercent', 0.15),
                     ('harmonicSuppression', False), ('pan', 0.0)
                 ],
                 "transition": [
@@ -1805,12 +1781,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startBaseFreq', 200.0), ('endBaseFreq', 200.0), ('startBeatFreq', 4.0), ('endBeatFreq', 4.0),
                     ('startForceMono', 0.0), ('endForceMono', 0.0),
                     ('startStartPhaseL', 0.0), ('endStartPhaseL', 0.0), ('startStartPhaseR', 0.0), ('endStartPhaseR', 0.0),
-                    ('startAmpOscDepthL', 0.0), ('endAmpOscDepthL', 0.0), ('startAmpOscFreqL', 0.0), ('endAmpOscFreqL', 0.0), ('startAmpOscPhaseOffsetL', 0.0), ('endAmpOscPhaseOffsetL', 0.0), ('startAmpOscStabilityL', 0.0), ('endAmpOscStabilityL', 0.0),
-                    ('startAmpOscDepthR', 0.0), ('endAmpOscDepthR', 0.0), ('startAmpOscFreqR', 0.0), ('endAmpOscFreqR', 0.0), ('startAmpOscPhaseOffsetR', 0.0), ('endAmpOscPhaseOffsetR', 0.0), ('startAmpOscStabilityR', 0.0), ('endAmpOscStabilityR', 0.0),
-                    ('startFreqOscRangeL', 0.0), ('endFreqOscRangeL', 0.0), ('startFreqOscFreqL', 0.0), ('endFreqOscFreqL', 0.0), ('startFreqOscSkewL', 0.0), ('endFreqOscSkewL', 0.0), ('startFreqOscPhaseOffsetL', 0.0), ('endFreqOscPhaseOffsetL', 0.0), ('startFreqOscStabilityL', 0.0), ('endFreqOscStabilityL', 0.0),
-                    ('startFreqOscRangeR', 0.0), ('endFreqOscRangeR', 0.0), ('startFreqOscFreqR', 0.0), ('endFreqOscFreqR', 0.0), ('startFreqOscSkewR', 0.0), ('endFreqOscSkewR', 0.0), ('startFreqOscPhaseOffsetR', 0.0), ('endFreqOscPhaseOffsetR', 0.0), ('startFreqOscStabilityR', 0.0), ('endFreqOscStabilityR', 0.0),
-                    ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0), ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0), ('startPhaseOscStability', 0.0), ('endPhaseOscStability', 0.0),
-                    ('startRampPercent', 0.2), ('endRampPercent', 0.2), ('startGapPercent', 0.15), ('endGapPercent', 0.15),
+                    ('startAmpOscDepthL', 0.0), ('endAmpOscDepthL', 0.0), ('startAmpOscFreqL', 0.0), ('endAmpOscFreqL', 0.0), ('startAmpOscPhaseOffsetL', 0.0), ('endAmpOscPhaseOffsetL', 0.0), ('startAmpOscDepthR', 0.0), ('endAmpOscDepthR', 0.0), ('startAmpOscFreqR', 0.0), ('endAmpOscFreqR', 0.0), ('startAmpOscPhaseOffsetR', 0.0), ('endAmpOscPhaseOffsetR', 0.0), ('startFreqOscRangeL', 0.0), ('endFreqOscRangeL', 0.0), ('startFreqOscFreqL', 0.0), ('endFreqOscFreqL', 0.0), ('startFreqOscSkewL', 0.0), ('endFreqOscSkewL', 0.0), ('startFreqOscPhaseOffsetL', 0.0), ('endFreqOscPhaseOffsetL', 0.0), ('startFreqOscRangeR', 0.0), ('endFreqOscRangeR', 0.0), ('startFreqOscFreqR', 0.0), ('endFreqOscFreqR', 0.0), ('startFreqOscSkewR', 0.0), ('endFreqOscSkewR', 0.0), ('startFreqOscPhaseOffsetR', 0.0), ('endFreqOscPhaseOffsetR', 0.0), ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0), ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0), ('startRampPercent', 0.2), ('endRampPercent', 0.2), ('startGapPercent', 0.15), ('endGapPercent', 0.15),
                     ('startHarmonicSuppression', False), ('endHarmonicSuppression', False), ('startPan', 0.0), ('endPan', 0.0),
                     ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
                 ]
@@ -1963,6 +1934,8 @@ class VoiceEditorDialog(QDialog): # Standard class name
                 return ordered_params
 
         for name, default_val in params_list:
+            if 'stability' in name.lower() and 'spatial' not in name.lower():
+                continue
             ordered_params[name] = default_val
 
         flange_defaults = [


### PR DESCRIPTION
## Summary
- stop exposing amplitude, frequency, and phase modulation stability controls
- filter non-spatial stability params from defaults so only spatial stability remains

## Testing
- `python -m py_compile audio/src/ui/voice_editor_dialog.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87f68d970832da724fe6f342b1a9e