### PR TITLE
Add additional noise color options to audio generator

### DIFF
--- a/audio/README.md
+++ b/audio/README.md
@@ -52,7 +52,7 @@ Available Synth Functions:
 `sound_creator.py` also includes essential DSP building blocks:
 
 * Sine wave generation (constant and varying frequency via phase accumulation).
-* Noise generation (white, pink via filtering/colorednoise lib, brown via integration).
+* Noise generation (white, pink via filtering/colorednoise lib, brown via integration, plus blue, purple, red, deep brown and green variants).
 * Butterworth filters (bandpass, band-reject, lowpass).
 * Envelope generators (ADSR, Linen, Linear Fade).
 * Stereo Panning (`pan2` using equal power law).

--- a/audio/src/ui/noise_generator_dialog.py
+++ b/audio/src/ui/noise_generator_dialog.py
@@ -86,7 +86,15 @@ class NoiseGeneratorDialog(QDialog):
 
         # Noise type
         self.noise_type_combo = QComboBox()
-        self.noise_type_combo.addItems(["Pink", "Brown"])
+        self.noise_type_combo.addItems([
+            "Pink",
+            "Brown",
+            "Green",
+            "Deep Brown",
+            "Purple",
+            "Red",
+            "Blue",
+        ])
         self.noise_type_combo.setToolTip("Base noise colour to generate")
         form.addRow("Noise Type:", self.noise_type_combo)
 
@@ -301,7 +309,7 @@ class NoiseGeneratorDialog(QDialog):
         """Apply ``params`` to the UI widgets."""
         self.duration_spin.setValue(params.duration_seconds)
         self.sample_rate_spin.setValue(params.sample_rate)
-        idx = self.noise_type_combo.findText(params.noise_type.capitalize())
+        idx = self.noise_type_combo.findText(params.noise_type.title())
         if idx != -1:
             self.noise_type_combo.setCurrentIndex(idx)
         idx = self.lfo_waveform_combo.findText(params.lfo_waveform.capitalize())


### PR DESCRIPTION
## Summary
- Support blue, purple, red, deep brown, and green noise generation
- Extend noise generator to select and synthesize new noise colors
- Document expanded noise color capabilities

## Testing
- `python -m py_compile audio/src/synth_functions/common.py audio/src/synth_functions/noise_flanger.py audio/src/ui/noise_generator_dialog.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8da4a2060832d99220da1e3d8e226