### PR TITLE
Add colored noise generator with interactive spectrogram

### DIFF
--- a/audio/requirements.txt
+++ b/audio/requirements.txt
@@ -9,3 +9,4 @@ pandas
 plotly>=5.20
 slab==1.8.0
 soundfile
+matplotlib

--- a/audio/src/__init__.py
+++ b/audio/src/__init__.py
@@ -14,6 +14,10 @@ from .utils.voice_file import (
     load_voice_preset_list,
 )
 from .utils.timeline_visualizer import visualize_track_timeline
+from .utils.colored_noise import (
+    ColoredNoiseGenerator,
+    plot_spectrogram,
+)
 
 __all__ = [
     'NoiseParams',
@@ -28,4 +32,6 @@ __all__ = [
     'save_voice_preset_list',
     'load_voice_preset_list',
     'visualize_track_timeline',
+    'ColoredNoiseGenerator',
+    'plot_spectrogram',
 ]

--- a/audio/src/utils/colored_noise.py
+++ b/audio/src/utils/colored_noise.py
@@ -1,0 +1,94 @@
+"""Colored noise generation and spectrogram visualization utilities."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from scipy.signal import butter, lfilter, spectrogram
+import matplotlib.pyplot as plt
+
+from ..synth_functions.common import _powerlaw_noise
+
+
+@dataclass
+class ColoredNoiseGenerator:
+    """Generate colored noise with configurable spectrum and filters.
+
+    Parameters
+    ----------
+    sample_rate : int
+        Sampling rate of the noise in Hz.
+    duration : float
+        Duration of the generated noise in seconds.
+    exponent : float
+        Power-law exponent for noise spectrum (0=white, 1=pink, 2=brown,
+        -1=blue, etc.).
+    lowcut : float, optional
+        Low cut-off frequency in Hz for optional filtering.
+    highcut : float, optional
+        High cut-off frequency in Hz for optional filtering.
+    amplitude : float
+        Output gain applied to the noise.
+    seed : int, optional
+        Random seed for reproducibility.
+    """
+
+    sample_rate: int = 44100
+    duration: float = 1.0
+    exponent: float = 1.0
+    lowcut: Optional[float] = None
+    highcut: Optional[float] = None
+    amplitude: float = 1.0
+    seed: Optional[int] = None
+
+    def generate(self) -> np.ndarray:
+        """Return generated noise as a NumPy array."""
+        n = int(self.duration * self.sample_rate)
+        if self.seed is not None:
+            np.random.seed(self.seed)
+        noise = _powerlaw_noise(self.exponent, n)
+        if self.lowcut is not None or self.highcut is not None:
+            nyq = 0.5 * self.sample_rate
+            low = self.lowcut / nyq if self.lowcut else None
+            high = self.highcut / nyq if self.highcut else None
+            if low and high:
+                b, a = butter(4, [low, high], btype="band")
+            elif low:
+                b, a = butter(4, low, btype="high")
+            else:
+                b, a = butter(4, high, btype="low")
+            noise = lfilter(b, a, noise)
+        return (noise * self.amplitude).astype(np.float32)
+
+
+def plot_spectrogram(noise: np.ndarray, sample_rate: int, cmap: str = "viridis") -> None:
+    """Display an interactive heatmap spectrogram of ``noise``.
+
+    Scrolling the mouse wheel over the plot zooms the frequency axis,
+    enabling inspection of different bands.
+    """
+    f, t, Sxx = spectrogram(noise, fs=sample_rate)
+    fig, ax = plt.subplots()
+    im = ax.pcolormesh(t, f, 10 * np.log10(Sxx + 1e-12), shading="auto", cmap=cmap)
+    ax.set_ylabel("Frequency [Hz]")
+    ax.set_xlabel("Time [s]")
+    fig.colorbar(im, ax=ax, label="dB")
+    ax.set_ylim(0, sample_rate / 2)
+
+    def _on_scroll(event):
+        if event.inaxes != ax or event.ydata is None:
+            return
+        cur_bottom, cur_top = ax.get_ylim()
+        center = event.ydata
+        scale = 1.2 if event.button == "up" else 1 / 1.2
+        new_range = (cur_top - cur_bottom) * scale
+        bottom = max(0, center - new_range / 2)
+        top = min(sample_rate / 2, center + new_range / 2)
+        ax.set_ylim(bottom, top)
+        ax.figure.canvas.draw_idle()
+
+    fig.canvas.mpl_connect("scroll_event", _on_scroll)
+    plt.show()
+
+
+__all__ = ["ColoredNoiseGenerator", "plot_spectrogram"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scipy==1.15.2
 slab==1.8.0
 plotly>=5.20
 pandas
+matplotlib


### PR DESCRIPTION
## Summary
- Add `ColoredNoiseGenerator` utility to create power-law based noise with optional filtering
- Provide `plot_spectrogram` viewer with scroll-wheel zoom for energy distribution
- Expose new utilities and include `matplotlib` dependency

## Testing
- `python -m py_compile audio/src/utils/colored_noise.py audio/src/__init__.py`
- `python - <<'PY'
from audio.src.utils.colored_noise import ColoredNoiseGenerator
from scipy.signal import spectrogram
cng = ColoredNoiseGenerator(duration=0.01, exponent=1.0, seed=0)
noise = cng.generate()
f,t,Sxx = spectrogram(noise, fs=cng.sample_rate)
print('noise', noise.shape)
print('spectrogram', Sxx.shape)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8f01d2178832d870202486e45af87