### PR TITLE
Refine transition timing controls

### DIFF
--- a/audio/src/models/models.py
+++ b/audio/src/models/models.py
@@ -108,7 +108,7 @@ class VoiceModel(QAbstractTableModel):
         "Beat Freq",
         "Transition?",
         "Init Offset",
-        "Post Offset",
+        "Transition Dur",
         "Description",
     ]
 
@@ -144,7 +144,11 @@ class VoiceModel(QAbstractTableModel):
             if index.column() == 4:
                 return self._format_number(params.get("initial_offset", 0.0)) if is_transition else "N/A"
             if index.column() == 5:
-                return self._format_number(params.get("post_offset", 0.0)) if is_transition else "N/A"
+                return (
+                    self._format_number(params.get("transition_duration", 0.0))
+                    if is_transition
+                    else "N/A"
+                )
             if index.column() == 6:
                 return description
         return None
@@ -254,7 +258,7 @@ class VoiceModel(QAbstractTableModel):
             return True
         if index.column() == 5:
             try:
-                voice.setdefault('params', {})['post_offset'] = float(value)
+                voice.setdefault('params', {})['transition_duration'] = float(value)
             except (ValueError, TypeError):
                 return False
             self.dataChanged.emit(index, index, [Qt.DisplayRole, Qt.EditRole])

--- a/audio/src/synth_functions/binaural_beat.py
+++ b/audio/src/synth_functions/binaural_beat.py
@@ -267,7 +267,9 @@ def _binaural_beat_core(
 from .common import calculate_transition_alpha
 
 
-def binaural_beat_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def binaural_beat_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     # --- Unpack start/end parameters ---
     startAmpL = float(params.get('startAmpL', params.get('ampL', 0.5)))
     endAmpL = float(params.get('endAmpL', startAmpL))
@@ -407,7 +409,9 @@ def binaural_beat_transition(duration, sample_rate=44100, initial_offset=0.0, po
         burst_arr = np.empty(0, dtype=np.float32)
 
     curve = params.get('transition_curve', 'linear')
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha_arr = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     audio = _binaural_beat_transition_core(
         N, float(duration), float(sample_rate),

--- a/audio/src/synth_functions/hybrid_qam_monaural_beat.py
+++ b/audio/src/synth_functions/hybrid_qam_monaural_beat.py
@@ -161,7 +161,9 @@ def _hybrid_qam_monaural_beat_core(
     return out
 
 
-def hybrid_qam_monaural_beat_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def hybrid_qam_monaural_beat_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """
     Generates a hybrid QAM-Monaural beat with parameters linearly interpolated.
     """
@@ -217,7 +219,9 @@ def hybrid_qam_monaural_beat_transition(duration, sample_rate=44100, initial_off
         return np.zeros((0, 2), dtype=np.float32)
 
     curve = params.get('transition_curve', 'linear')
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha_arr = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     raw_signal = _hybrid_qam_monaural_beat_transition_core(
         N, float(duration), float(sample_rate),

--- a/audio/src/synth_functions/isochronic_tone.py
+++ b/audio/src/synth_functions/isochronic_tone.py
@@ -256,7 +256,9 @@ def isochronic_tone(duration, sample_rate=44100, **params):
     return audio
 
 
-def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def isochronic_tone_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
 
     """Transitioning version of :func:`isochronic_tone`."""
 
@@ -335,7 +337,9 @@ def isochronic_tone_transition(duration, sample_rate=44100, initial_offset=0.0, 
     t = np.linspace(0, duration, N, endpoint=False)
 
     curve = params.get('transition_curve', 'linear')
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     # --- Interpolate Parameters ---
     base_freq_array = startBaseFreq + (endBaseFreq - startBaseFreq) * alpha

--- a/audio/src/synth_functions/monaural_beat_stereo_amps.py
+++ b/audio/src/synth_functions/monaural_beat_stereo_amps.py
@@ -117,7 +117,9 @@ def _monaural_beat_stereo_amps_core(
     return out
 
 
-def monaural_beat_stereo_amps_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def monaural_beat_stereo_amps_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     s_ll = float(params.get('start_amp_lower_L', params.get('amp_lower_L', 0.5)))
     e_ll = float(params.get('end_amp_lower_L',   s_ll))
     s_ul = float(params.get('start_amp_upper_L', params.get('amp_upper_L', 0.5)))
@@ -151,7 +153,9 @@ def monaural_beat_stereo_amps_transition(duration, sample_rate=44100, initial_of
 
     N = int(duration * sample_rate)
     curve = params.get('transition_curve', 'linear')
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha_arr = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
     return _monaural_beat_stereo_amps_transition_core(
         N, float(duration), float(sample_rate),
         s_ll, e_ll, s_ul, e_ul, s_lr, e_lr, s_ur, e_ur,

--- a/audio/src/synth_functions/qam_beat.py
+++ b/audio/src/synth_functions/qam_beat.py
@@ -249,7 +249,9 @@ def _qam_beat_core(
 from .common import calculate_transition_alpha
 
 
-def qam_beat_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def qam_beat_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """
     Enhanced QAM-based binaural beat with parameter transitions.
     Includes all enhanced features with smooth interpolation.
@@ -340,7 +342,9 @@ def qam_beat_transition(duration, sample_rate=44100, initial_offset=0.0, post_of
         return np.zeros((0, 2), dtype=np.float32)
     
     curve = params.get('transition_curve', 'linear')
-    alpha_arr = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha_arr = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     raw_signal = _qam_beat_transition_core(
         N, float(duration), float(sample_rate),

--- a/audio/src/synth_functions/rhythmic_waveshaping.py
+++ b/audio/src/synth_functions/rhythmic_waveshaping.py
@@ -38,7 +38,9 @@ def rhythmic_waveshaping(duration, sample_rate=44100, **params):
 
 
 
-def rhythmic_waveshaping_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def rhythmic_waveshaping_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """Rhythmic waveshaping with parameter transitions."""
     amp = float(params.get('amp', 0.25))
     startCarrierFreq = float(params.get('startCarrierFreq', 200))
@@ -58,7 +60,9 @@ def rhythmic_waveshaping_transition(duration, sample_rate=44100, initial_offset=
     t_abs = t_rel
 
     curve = params.get('transition_curve', 'linear')
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     # Interpolate parameters using alpha
     currentCarrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * alpha

--- a/audio/src/synth_functions/spatial_angle_modulation.py
+++ b/audio/src/synth_functions/spatial_angle_modulation.py
@@ -236,7 +236,9 @@ def spatial_angle_modulation(duration, sample_rate=44100, **params):
         return np.zeros((N, 2))
 
 
-def spatial_angle_modulation_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def spatial_angle_modulation_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """Spatial Angle Modulation with parameter transitions."""
     if not AUDIO_ENGINE_AVAILABLE:
         print("Error: SAM transition function called, but audio_engine module is missing.")
@@ -371,7 +373,9 @@ def spatial_angle_modulation_monaural_beat(duration, sample_rate=44100, **params
     return stereo_out
 
 
-def spatial_angle_modulation_monaural_beat_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def spatial_angle_modulation_monaural_beat_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """Spatial Angle Modulation monaural beat with transitions."""
     N = int(duration * sample_rate)
     if N <= 0:

--- a/audio/src/synth_functions/stereo_am_independent.py
+++ b/audio/src/synth_functions/stereo_am_independent.py
@@ -41,7 +41,9 @@ def stereo_am_independent(duration, sample_rate=44100, **params):
     return np.vstack([outputL, outputR]).T
 
 
-def stereo_am_independent_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def stereo_am_independent_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """Stereo AM Independent with parameter transitions."""
     amp = float(params.get('amp', 0.25))
     startCarrierFreq = float(params.get('startCarrierFreq', 200))
@@ -66,7 +68,9 @@ def stereo_am_independent_transition(duration, sample_rate=44100, initial_offset
     t_abs = t_rel
 
     curve = params.get('transition_curve', 'linear')
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     # Interpolate parameters using alpha
     currentCarrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * alpha

--- a/audio/src/synth_functions/wave_shape_stereo_am.py
+++ b/audio/src/synth_functions/wave_shape_stereo_am.py
@@ -55,7 +55,9 @@ def wave_shape_stereo_am(duration, sample_rate=44100, **params):
     return np.vstack([outputL, outputR]).T
 
 
-def wave_shape_stereo_am_transition(duration, sample_rate=44100, initial_offset=0.0, post_offset=0.0, **params):
+def wave_shape_stereo_am_transition(
+    duration, sample_rate=44100, initial_offset=0.0, transition_duration=None, **params
+):
     """Combined waveshaping and stereo AM with parameter transitions."""
     amp = float(params.get('amp', 0.15))
     startCarrierFreq = float(params.get('startCarrierFreq', 200))
@@ -84,7 +86,9 @@ def wave_shape_stereo_am_transition(duration, sample_rate=44100, initial_offset=
     t_abs = t_rel
 
     curve = params.get('transition_curve', 'linear')
-    alpha = calculate_transition_alpha(duration, sample_rate, initial_offset, post_offset, curve)
+    alpha = calculate_transition_alpha(
+        duration, sample_rate, initial_offset, transition_duration, curve
+    )
 
     # Interpolate parameters using alpha
     currentCarrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * alpha

--- a/audio/src/ui/voice_editor_dialog.py
+++ b/audio/src/ui/voice_editor_dialog.py
@@ -1739,7 +1739,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startModFreq', 12), ('endModFreq', 7.83),
                     ('startModDepth', 1.0), ('endModDepth', 1.0),
                     ('startShapeAmount', 5.0), ('endShapeAmount', 5.0), ('pan', 0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "stereo_am_independent": { # This is an example, ensure it's correct
@@ -1757,7 +1757,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startModDepthR', 0.8), ('endModDepthR', 0.8),
                     ('startModPhaseR', 0),
                     ('startStereoWidthHz', 0.2), ('endStereoWidthHz', 0.2),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "wave_shape_stereo_am": { # This is an example, ensure it's correct
@@ -1779,7 +1779,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startStereoModFreqR', 4.0), ('endStereoModFreqR', 6.1),
                     ('startStereoModDepthR', 0.9), ('endStereoModDepthR', 0.9),
                     ('startStereoModPhaseR', math.pi / 2),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "spatial_angle_modulation": {
@@ -1798,7 +1798,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startArcStartDeg', 0.0), ('endArcStartDeg', 0.0),
                     ('startArcEndDeg', 360.0), ('endArcEndDeg', 360.0),
                     ('frame_dur_ms', 46.4), ('overlap_factor', 8),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "binaural_beat": {
@@ -1821,7 +1821,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startFreqOscSkewR', 0.0), ('endFreqOscSkewR', 0.0), ('startFreqOscPhaseOffsetR', 0.0), ('endFreqOscPhaseOffsetR', 0.0),
                     ('freqOscShape', 'sine'),
                     ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0), ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "monaural_beat_stereo_amps": { # This is an example, ensure it's correct
@@ -1846,7 +1846,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0),
                     ('startAmpOscDepth', 0.0), ('endAmpOscDepth', 0.0),
                     ('startAmpOscFreq', 0.0), ('endAmpOscFreq', 0.0),
-                    ('startAmpOscPhaseOffset', 0.0), ('endAmpOscPhaseOffset', 0.0), ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('startAmpOscPhaseOffset', 0.0), ('endAmpOscPhaseOffset', 0.0), ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "spatial_angle_modulation_monaural_beat": {
@@ -1881,7 +1881,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startPathRadius', 1.0), ('endPathRadius', 1.0),
                     ('startAmp', 0.7), ('endAmp', 0.7),
                     ('frame_dur_ms', 46.4), ('overlap_factor', 8),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "isochronic_tone": {
@@ -1899,7 +1899,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startStartPhaseL', 0.0), ('endStartPhaseL', 0.0), ('startStartPhaseR', 0.0), ('endStartPhaseR', 0.0),
                     ('startAmpOscDepthL', 0.0), ('endAmpOscDepthL', 0.0), ('startAmpOscFreqL', 0.0), ('endAmpOscFreqL', 0.0), ('startAmpOscPhaseOffsetL', 0.0), ('endAmpOscPhaseOffsetL', 0.0), ('startAmpOscDepthR', 0.0), ('endAmpOscDepthR', 0.0), ('startAmpOscFreqR', 0.0), ('endAmpOscFreqR', 0.0), ('startAmpOscPhaseOffsetR', 0.0), ('endAmpOscPhaseOffsetR', 0.0), ('startFreqOscRangeL', 0.0), ('endFreqOscRangeL', 0.0), ('startFreqOscFreqL', 0.0), ('endFreqOscFreqL', 0.0), ('startFreqOscSkewL', 0.0), ('endFreqOscSkewL', 0.0), ('startFreqOscPhaseOffsetL', 0.0), ('endFreqOscPhaseOffsetL', 0.0), ('startFreqOscRangeR', 0.0), ('endFreqOscRangeR', 0.0), ('startFreqOscFreqR', 0.0), ('endFreqOscFreqR', 0.0), ('startFreqOscSkewR', 0.0), ('endFreqOscSkewR', 0.0), ('startFreqOscPhaseOffsetR', 0.0), ('endFreqOscPhaseOffsetR', 0.0), ('startPhaseOscFreq', 0.0), ('endPhaseOscFreq', 0.0), ('startPhaseOscRange', 0.0), ('endPhaseOscRange', 0.0), ('startRampPercent', 0.2), ('endRampPercent', 0.2), ('startGapPercent', 0.15), ('endGapPercent', 0.15),
                     ('startHarmonicSuppression', False), ('endHarmonicSuppression', False), ('startPan', 0.0), ('endPan', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "qam_beat": { # CORRECTED AND COMPLETED for qam_beat based on qam_beat.py
@@ -1955,7 +1955,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('sidebandDepth', 0.1),
                     ('attackTime', 0.0),
                     ('releaseTime', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             },
             "hybrid_qam_monaural_beat": { # This is an example, ensure it's correct
@@ -1990,7 +1990,7 @@ class VoiceEditorDialog(QDialog): # Standard class name
                     ('startMonoPhaseOscFreqR', 0.0), ('endMonoPhaseOscFreqR', 0.0),
                     ('startMonoPhaseOscRangeR', 0.0), ('endMonoPhaseOscRangeR', 0.0),
                     ('startMonoPhaseOscPhaseOffsetR', 0.0), ('endMonoPhaseOscPhaseOffsetR', 0.0),
-                    ('initial_offset', 0.0), ('post_offset', 0.0), ('transition_curve', 'linear')
+                    ('initial_offset', 0.0), ('transition_duration', 0.0), ('transition_curve', 'linear')
                 ]
             }
         }


### PR DESCRIPTION
## Summary
- replace the old post-offset timing with explicit transition durations across audio synth functions, UI controls, and realtime voices
- clamp transition duration values based on total length and migrate legacy data when loading saved noise presets

## Testing
- python -m compileall audio/src

------
https://chatgpt.com/codex/tasks/task_e_68ccdff07344832da7815bd58de83e71